### PR TITLE
Patch ralph to emit structured events to shared events.jsonl (#6)

### DIFF
--- a/lib/ralph-events.sh
+++ b/lib/ralph-events.sh
@@ -14,26 +14,57 @@
 # Envelope schema version — must match src/smart_ralph/eventlog.py.
 RALPH_EVENTS_SCHEMA_VERSION=1
 
-# emit_event <type> <issue|""> <payload_json>
+# _ralph_ts — emit ISO 8601 UTC timestamp.
+#
+# Prefers GNU date / gdate for millisecond precision; falls back to bash's
+# printf '%(...)T' builtin (no fork) on platforms without %N-aware date.
+# The backend is probed once and memoized in _RALPH_TS_IMPL.
+_ralph_ts() {
+  if [[ -z "${_RALPH_TS_IMPL:-}" ]]; then
+    if command -v gdate >/dev/null 2>&1; then
+      _RALPH_TS_IMPL="gdate"
+    elif [[ "$(date -u +%N 2>/dev/null)" =~ ^[0-9]{9}$ ]]; then
+      _RALPH_TS_IMPL="gnu-date"
+    else
+      _RALPH_TS_IMPL="bash-builtin"
+    fi
+    export _RALPH_TS_IMPL
+  fi
+  case "$_RALPH_TS_IMPL" in
+    gdate)        gdate -u +"%Y-%m-%dT%H:%M:%S.%3NZ" ;;
+    gnu-date)     date -u +"%Y-%m-%dT%H:%M:%S.%3NZ" ;;
+    bash-builtin) printf '%(%Y-%m-%dT%H:%M:%S.000Z)T' -1 ;;
+  esac
+}
+
+# _ralph_byte_len — byte count of stdin, locale-independent.
+_ralph_byte_len() {
+  wc -c
+}
+
+# emit_event <type> <issue|""> [<payload_json>]
 #
 # Writes one envelope JSON line via O_APPEND (shell `>>` is POSIX O_APPEND,
-# atomic for writes ≤ PIPE_BUF ≈ 4KB). issue may be empty or "null" for
-# nullable; otherwise pass a bare integer.
+# atomic for writes ≤ PIPE_BUF ≈ 4KB). issue may be empty, "null", or any
+# non-integer (all coerced to null); otherwise pass a bare integer. payload
+# defaults to an empty object when omitted.
 emit_event() {
   [[ -z "${SMART_RALPH_RUN_ID:-}" ]] && return 0
 
   local type="$1"
   local issue="${2:-}"
-  local payload_json="${3:-{\}}"
+  local payload_json="${3:-}"
+  [[ -z "$payload_json" ]] && payload_json="{}"
 
   local events_path="${SMART_RALPH_EVENTS_PATH:-.smart-ralph/events.jsonl}"
 
-  # ts in ISO 8601 UTC with millisecond precision.
   local ts
-  ts=$(python3 -c "from datetime import datetime, timezone; n = datetime.now(timezone.utc); print(n.strftime('%Y-%m-%dT%H:%M:%S.') + f'{n.microsecond // 1000:03d}Z')")
+  ts=$(_ralph_ts)
 
+  # Coerce anything that isn't a plain integer (or "null"/empty) to null so
+  # jq --argjson never ingests unvalidated strings as raw JSON.
   local issue_arg
-  if [[ -z "$issue" || "$issue" == "null" ]]; then
+  if [[ -z "$issue" || "$issue" == "null" || ! "$issue" =~ ^-?[0-9]+$ ]]; then
     issue_arg="null"
   else
     issue_arg="$issue"
@@ -49,20 +80,23 @@ emit_event() {
     --argjson payload "$payload_json" \
     '{schema_version:$sv, ts:$ts, run_id:$rid, type:$type, source:"ralph", issue:$issue, payload:$payload}')
 
-  # POSIX atomic-append guarantee is ≤ PIPE_BUF (~4KB including newline).
-  # Oversized payloads are offloaded to a sidecar blob; the line keeps only
-  # a reference so concurrent writers never interleave partial data.
-  if (( ${#line} + 1 > 4096 )); then
-    local events_root blob_dir blob_rel blob_path
+  # Byte-accurate size check: UTF-8 multi-byte chars can push a line past
+  # PIPE_BUF even when char count is under the limit. ${#line} is chars;
+  # wc -c is bytes.
+  local line_bytes
+  line_bytes=$(printf '%s\n' "$line" | _ralph_byte_len)
+  if (( line_bytes > 4096 )); then
+    local events_root blob_dir blob_rel blob_path blob_name
     events_root=$(dirname "$events_path")
     blob_dir="$events_root/blobs/$SMART_RALPH_RUN_ID"
     mkdir -p "$blob_dir"
-    local blob_name="$(date -u +%s%N)-$$.json"
+    blob_name="$(date -u +%s%N 2>/dev/null || date -u +%s)-$$.json"
     blob_path="$blob_dir/$blob_name"
     printf '%s' "$payload_json" > "$blob_path"
 
-    # blob_ref is relative to the cwd so supervisor can resolve it.
-    blob_rel="${blob_path#$PWD/}"
+    # blob_ref is relative to events_root so readers can resolve it
+    # regardless of the process cwd at read time.
+    blob_rel="${blob_path#${events_root}/}"
     line=$(jq -nc \
       --argjson sv "$RALPH_EVENTS_SCHEMA_VERSION" \
       --arg ts "$ts" \

--- a/lib/ralph-events.sh
+++ b/lib/ralph-events.sh
@@ -14,15 +14,15 @@
 # Envelope schema version — must match src/smart_ralph/eventlog.py.
 # Guarded so re-sourcing the helper (e.g., from a wrapper that also sources
 # ralph) is a silent no-op instead of a "readonly variable" error.
-[[ -z "${RALPH_EVENTS_SCHEMA_VERSION:-}" ]] && readonly RALPH_EVENTS_SCHEMA_VERSION=1
+[[ -v RALPH_EVENTS_SCHEMA_VERSION ]] || readonly RALPH_EVENTS_SCHEMA_VERSION=1
 
 # Char-count threshold above which we fall through to a byte-accurate
 # check. UTF-8 is at most 4 bytes/char, so any line with ≤1022 chars
 # (this threshold minus the trailing newline) is guaranteed ≤ 4089 bytes,
 # safely under the 4096-byte PIPE_BUF window. At 1023+ chars we fall
 # through to an exact wc -c check.
-[[ -z "${RALPH_EVENTS_BYTE_CHECK_CHAR_THRESHOLD:-}" ]] && \
-  readonly RALPH_EVENTS_BYTE_CHECK_CHAR_THRESHOLD=1023
+[[ -v RALPH_EVENTS_BYTE_CHECK_CHAR_THRESHOLD ]] \
+  || readonly RALPH_EVENTS_BYTE_CHECK_CHAR_THRESHOLD=1023
 
 # _ralph_ts — emit ISO 8601 UTC timestamp.
 #

--- a/lib/ralph-events.sh
+++ b/lib/ralph-events.sh
@@ -12,13 +12,17 @@
 # runs standalone without polluting the filesystem.
 
 # Envelope schema version — must match src/smart_ralph/eventlog.py.
-readonly RALPH_EVENTS_SCHEMA_VERSION=1
+# Guarded so re-sourcing the helper (e.g., from a wrapper that also sources
+# ralph) is a silent no-op instead of a "readonly variable" error.
+[[ -z "${RALPH_EVENTS_SCHEMA_VERSION:-}" ]] && readonly RALPH_EVENTS_SCHEMA_VERSION=1
 
 # Char-count threshold above which we fall through to a byte-accurate
-# check. UTF-8 is at most 4 bytes/char. 1023 chars × 4 bytes + 1 byte for
-# the trailing newline = 4093 bytes, safely under the 4096-byte PIPE_BUF
-# atomicity window even in the adversarial all-4-byte-UTF-8 case.
-readonly RALPH_EVENTS_BYTE_CHECK_CHAR_THRESHOLD=1023
+# check. UTF-8 is at most 4 bytes/char, so any line with ≤1022 chars
+# (this threshold minus the trailing newline) is guaranteed ≤ 4089 bytes,
+# safely under the 4096-byte PIPE_BUF window. At 1023+ chars we fall
+# through to an exact wc -c check.
+[[ -z "${RALPH_EVENTS_BYTE_CHECK_CHAR_THRESHOLD:-}" ]] && \
+  readonly RALPH_EVENTS_BYTE_CHECK_CHAR_THRESHOLD=1023
 
 # _ralph_ts — emit ISO 8601 UTC timestamp.
 #

--- a/lib/ralph-events.sh
+++ b/lib/ralph-events.sh
@@ -14,6 +14,11 @@
 # Envelope schema version — must match src/smart_ralph/eventlog.py.
 RALPH_EVENTS_SCHEMA_VERSION=1
 
+# Char-count threshold above which we fall through to a byte-accurate
+# check. UTF-8 is at most 4 bytes per char, so any line with ≤1024 chars
+# cannot exceed the 4KB PIPE_BUF window. Above that, fall through.
+RALPH_EVENTS_BYTE_CHECK_CHAR_THRESHOLD=1024
+
 # _ralph_ts — emit ISO 8601 UTC timestamp.
 #
 # Prefers GNU date / gdate for millisecond precision; falls back to bash's
@@ -21,25 +26,21 @@ RALPH_EVENTS_SCHEMA_VERSION=1
 # The backend is probed once and memoized in _RALPH_TS_IMPL.
 _ralph_ts() {
   if [[ -z "${_RALPH_TS_IMPL:-}" ]]; then
+    # Probe the exact format we'll use (+%3N) rather than +%N — some
+    # BSD-derived dates accept %N but reject precision modifiers like %3N.
     if command -v gdate >/dev/null 2>&1; then
       _RALPH_TS_IMPL="gdate"
-    elif [[ "$(date -u +%N 2>/dev/null)" =~ ^[0-9]{9}$ ]]; then
+    elif [[ "$(date -u +%3N 2>/dev/null)" =~ ^[0-9]{3}$ ]]; then
       _RALPH_TS_IMPL="gnu-date"
     else
       _RALPH_TS_IMPL="bash-builtin"
     fi
-    export _RALPH_TS_IMPL
   fi
   case "$_RALPH_TS_IMPL" in
     gdate)        gdate -u +"%Y-%m-%dT%H:%M:%S.%3NZ" ;;
     gnu-date)     date -u +"%Y-%m-%dT%H:%M:%S.%3NZ" ;;
     bash-builtin) printf '%(%Y-%m-%dT%H:%M:%S.000Z)T' -1 ;;
   esac
-}
-
-# _ralph_byte_len — byte count of stdin, locale-independent.
-_ralph_byte_len() {
-  wc -c
 }
 
 # emit_event <type> <issue|""> [<payload_json>]
@@ -80,17 +81,29 @@ emit_event() {
     --argjson payload "$payload_json" \
     '{schema_version:$sv, ts:$ts, run_id:$rid, type:$type, source:"ralph", issue:$issue, payload:$payload}')
 
-  # Byte-accurate size check: UTF-8 multi-byte chars can push a line past
-  # PIPE_BUF even when char count is under the limit. ${#line} is chars;
-  # wc -c is bytes.
-  local line_bytes
-  line_bytes=$(printf '%s\n' "$line" | _ralph_byte_len)
-  if (( line_bytes > 4096 )); then
+  # Fast path: if char count is well under 4KB, byte count cannot exceed
+  # 4KB either (UTF-8 is at most 4 bytes/char and almost all payloads are
+  # mostly ASCII). Only fork wc -c when we're close enough that multi-byte
+  # content could matter.
+  local needs_offload=0
+  if (( ${#line} + 1 > 4096 )); then
+    needs_offload=1
+  elif (( ${#line} + 1 > RALPH_EVENTS_BYTE_CHECK_CHAR_THRESHOLD )); then
+    local line_bytes
+    line_bytes=$(printf '%s\n' "$line" | wc -c)
+    (( line_bytes > 4096 )) && needs_offload=1
+  fi
+
+  if (( needs_offload )); then
     local events_root blob_dir blob_rel blob_path blob_name
     events_root=$(dirname "$events_path")
     blob_dir="$events_root/blobs/$SMART_RALPH_RUN_ID"
     mkdir -p "$blob_dir"
-    blob_name="$(date -u +%s%N 2>/dev/null || date -u +%s)-$$.json"
+    # Uniqueness comes from (ts digits) + pid + $RANDOM — portable across
+    # BSD and GNU date since we reuse _ralph_ts and strip non-digits.
+    local ts_digits
+    ts_digits=$(_ralph_ts | tr -dc '0-9')
+    blob_name="${ts_digits}-$$-${RANDOM}.json"
     blob_path="$blob_dir/$blob_name"
     printf '%s' "$payload_json" > "$blob_path"
 

--- a/lib/ralph-events.sh
+++ b/lib/ralph-events.sh
@@ -1,0 +1,78 @@
+# ralph-events.sh — structured event emission for ralph.
+#
+# Emits envelope-shaped JSONL events to .smart-ralph/events.jsonl so the
+# smart-ralph supervisor can observe ralph's internal lifecycle alongside
+# its own events. Source this file; do not execute it directly.
+#
+# Controlled by environment:
+#   SMART_RALPH_RUN_ID       — supervisor-assigned run id (required to emit)
+#   SMART_RALPH_EVENTS_PATH  — absolute path to events.jsonl
+#
+# When SMART_RALPH_RUN_ID is unset, emit_event is a silent no-op so ralph
+# runs standalone without polluting the filesystem.
+
+# Envelope schema version — must match src/smart_ralph/eventlog.py.
+RALPH_EVENTS_SCHEMA_VERSION=1
+
+# emit_event <type> <issue|""> <payload_json>
+#
+# Writes one envelope JSON line via O_APPEND (shell `>>` is POSIX O_APPEND,
+# atomic for writes ≤ PIPE_BUF ≈ 4KB). issue may be empty or "null" for
+# nullable; otherwise pass a bare integer.
+emit_event() {
+  [[ -z "${SMART_RALPH_RUN_ID:-}" ]] && return 0
+
+  local type="$1"
+  local issue="${2:-}"
+  local payload_json="${3:-{\}}"
+
+  local events_path="${SMART_RALPH_EVENTS_PATH:-.smart-ralph/events.jsonl}"
+
+  # ts in ISO 8601 UTC with millisecond precision.
+  local ts
+  ts=$(python3 -c "from datetime import datetime, timezone; n = datetime.now(timezone.utc); print(n.strftime('%Y-%m-%dT%H:%M:%S.') + f'{n.microsecond // 1000:03d}Z')")
+
+  local issue_arg
+  if [[ -z "$issue" || "$issue" == "null" ]]; then
+    issue_arg="null"
+  else
+    issue_arg="$issue"
+  fi
+
+  local line
+  line=$(jq -nc \
+    --argjson sv "$RALPH_EVENTS_SCHEMA_VERSION" \
+    --arg ts "$ts" \
+    --arg rid "$SMART_RALPH_RUN_ID" \
+    --arg type "$type" \
+    --argjson issue "$issue_arg" \
+    --argjson payload "$payload_json" \
+    '{schema_version:$sv, ts:$ts, run_id:$rid, type:$type, source:"ralph", issue:$issue, payload:$payload}')
+
+  # POSIX atomic-append guarantee is ≤ PIPE_BUF (~4KB including newline).
+  # Oversized payloads are offloaded to a sidecar blob; the line keeps only
+  # a reference so concurrent writers never interleave partial data.
+  if (( ${#line} + 1 > 4096 )); then
+    local events_root blob_dir blob_rel blob_path
+    events_root=$(dirname "$events_path")
+    blob_dir="$events_root/blobs/$SMART_RALPH_RUN_ID"
+    mkdir -p "$blob_dir"
+    local blob_name="$(date -u +%s%N)-$$.json"
+    blob_path="$blob_dir/$blob_name"
+    printf '%s' "$payload_json" > "$blob_path"
+
+    # blob_ref is relative to the cwd so supervisor can resolve it.
+    blob_rel="${blob_path#$PWD/}"
+    line=$(jq -nc \
+      --argjson sv "$RALPH_EVENTS_SCHEMA_VERSION" \
+      --arg ts "$ts" \
+      --arg rid "$SMART_RALPH_RUN_ID" \
+      --arg type "$type" \
+      --argjson issue "$issue_arg" \
+      --arg blob_ref "$blob_rel" \
+      '{schema_version:$sv, ts:$ts, run_id:$rid, type:$type, source:"ralph", issue:$issue, payload:{oversized:true, blob_ref:$blob_ref}}')
+  fi
+
+  mkdir -p "$(dirname "$events_path")"
+  printf '%s\n' "$line" >> "$events_path"
+}

--- a/lib/ralph-events.sh
+++ b/lib/ralph-events.sh
@@ -12,12 +12,13 @@
 # runs standalone without polluting the filesystem.
 
 # Envelope schema version — must match src/smart_ralph/eventlog.py.
-RALPH_EVENTS_SCHEMA_VERSION=1
+readonly RALPH_EVENTS_SCHEMA_VERSION=1
 
 # Char-count threshold above which we fall through to a byte-accurate
-# check. UTF-8 is at most 4 bytes per char, so any line with ≤1024 chars
-# cannot exceed the 4KB PIPE_BUF window. Above that, fall through.
-RALPH_EVENTS_BYTE_CHECK_CHAR_THRESHOLD=1024
+# check. UTF-8 is at most 4 bytes/char. 1023 chars × 4 bytes + 1 byte for
+# the trailing newline = 4093 bytes, safely under the 4096-byte PIPE_BUF
+# atomicity window even in the adversarial all-4-byte-UTF-8 case.
+readonly RALPH_EVENTS_BYTE_CHECK_CHAR_THRESHOLD=1023
 
 # _ralph_ts — emit ISO 8601 UTC timestamp.
 #
@@ -99,11 +100,14 @@ emit_event() {
     events_root=$(dirname "$events_path")
     blob_dir="$events_root/blobs/$SMART_RALPH_RUN_ID"
     mkdir -p "$blob_dir"
-    # Uniqueness comes from (ts digits) + pid + $RANDOM — portable across
-    # BSD and GNU date since we reuse _ralph_ts and strip non-digits.
+    # Uniqueness comes from (ts digits) + pid + 30-bit random. Portable
+    # across BSD and GNU date since we reuse _ralph_ts and strip non-digits.
+    # Two $RANDOM values give 30 bits of entropy, not 15, so collisions
+    # within the same ms from the same process are ~1/10^9 instead of
+    # ~1/32k.
     local ts_digits
     ts_digits=$(_ralph_ts | tr -dc '0-9')
-    blob_name="${ts_digits}-$$-${RANDOM}.json"
+    blob_name="${ts_digits}-$$-${RANDOM}${RANDOM}.json"
     blob_path="$blob_dir/$blob_name"
     printf '%s' "$payload_json" > "$blob_path"
 

--- a/ralph
+++ b/ralph
@@ -279,6 +279,9 @@ PROMPT
       ok "  Issue #${issue} complete after ${i} iteration(s)"
       emit_event ralph_iteration_ended "$issue" \
         "$(jq -nc --argjson i "$i" --arg o "complete" '{iteration:$i, outcome:$o}')"
+      emit_event ralph_issue_ended "$issue" \
+        "$(jq -nc --arg o "complete" --argjson n "$i" \
+            '{outcome:$o, iterations:$n}')"
       return 0
     fi
 

--- a/ralph
+++ b/ralph
@@ -61,8 +61,11 @@ preflight() {
     err "Not inside a git repository"
     exit 1
   fi
-  if ((BASH_VERSINFO[0] < 4)); then
-    err "Bash 4+ required (have $BASH_VERSION). Install via: brew install bash"
+  # Require bash 4.2+ — printf '%(...)T' date builtin (used by the
+  # structured-events helper) landed in 4.2 (2011-02).
+  if ((BASH_VERSINFO[0] < 4)) || \
+     ((BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] < 2)); then
+    err "Bash 4.2+ required (have $BASH_VERSION). Install via: brew install bash"
     exit 1
   fi
   git worktree prune 2>/dev/null || true

--- a/ralph
+++ b/ralph
@@ -1,6 +1,19 @@
 #!/usr/bin/env bash
 set -o pipefail
 
+# Structured event emission (no-op unless supervisor sets SMART_RALPH_RUN_ID).
+_ralph_root="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck disable=SC1091
+source "$_ralph_root/lib/ralph-events.sh"
+
+# On any exit path, emit ralph_exit with the final exit code. Trap captures
+# $? as the first thing so it reflects the exiting command's status.
+_ralph_on_exit() {
+  local ec=$?
+  emit_event ralph_exit "" "$(jq -nc --argjson c "$ec" '{exit_code:$c}')" || true
+}
+trap _ralph_on_exit EXIT
+
 # ralph — Automated TDD issue orchestrator
 #
 # Processes GitHub issues from a PRD with dependency ordering,
@@ -81,9 +94,12 @@ get_state() {
 }
 
 set_state() {
+  local old; old=$(get_state "$1")
   local tmp; tmp=$(mktemp)
   jq --arg i "$1" --arg s "$2" '.issues[$i] = $s' "$(state_file)" > "$tmp"
   mv "$tmp" "$(state_file)"
+  emit_event ralph_state_transition "$1" \
+    "$(jq -nc --arg f "$old" --arg t "$2" '{from:$f, to:$t}')"
 }
 
 save_meta() {
@@ -154,6 +170,9 @@ run_issue() {
   local worktree="${WORKTREE_PREFIX}/issue-${issue}-${slug}"
 
   log "Running #${issue}: ${title} (mode: ${mode}, max ${max} iterations)"
+  emit_event ralph_issue_started "$issue" \
+    "$(jq -nc --arg t "$title" --arg m "$mode" --argjson n "$max" \
+        '{title:$t, mode:$m, max_iterations:$n}')"
 
   # Ensure worktree branches from latest main
   local main; main=$(default_branch)
@@ -226,6 +245,8 @@ PROMPT
 
   for ((i = 1; i <= max; i++)); do
     log "  Iteration ${i}/${max}"
+    emit_event ralph_iteration_started "$issue" \
+      "$(jq -nc --argjson i "$i" --argjson n "$max" '{iteration:$i, max:$n}')"
     local tmp; tmp=$(mktemp)
 
     if claude --dangerously-skip-permissions \
@@ -256,11 +277,22 @@ PROMPT
 
     if [[ "$result" == *"<promise>COMPLETE</promise>"* ]]; then
       ok "  Issue #${issue} complete after ${i} iteration(s)"
+      emit_event ralph_iteration_ended "$issue" \
+        "$(jq -nc --argjson i "$i" --arg o "complete" '{iteration:$i, outcome:$o}')"
       return 0
     fi
+
+    emit_event ralph_iteration_ended "$issue" \
+      "$(jq -nc --argjson i "$i" --arg o "continue" '{iteration:$i, outcome:$o}')"
   done
 
   warn "  Issue #${issue} incomplete after ${max} iterations"
+  emit_event ralph_error "$issue" \
+    "$(jq -nc --arg r "iterations_exhausted" --argjson n "$max" \
+        '{reason:$r, iterations:$n}')"
+  emit_event ralph_issue_ended "$issue" \
+    "$(jq -nc --arg o "incomplete" --argjson n "$max" \
+        '{outcome:$o, iterations:$n}')"
   return 1
 }
 
@@ -356,10 +388,14 @@ merge_issue() {
 
   if [[ -z "$pr" ]]; then
     warn "  No open PR found for #${issue}"
+    emit_event ralph_merge_failed "$issue" \
+      "$(jq -nc --arg r "no_pr_found" '{reason:$r}')"
     return 1
   fi
 
   log "  Merging PR #${pr}"
+  emit_event ralph_merge_attempted "$issue" \
+    "$(jq -nc --argjson pr "$pr" '{pr:$pr}')"
   gh pr merge "$pr" --merge --delete-branch 2>/dev/null || true
 
   # Verify the PR actually merged (don't trust exit code — branch cleanup
@@ -368,8 +404,14 @@ merge_issue() {
   pr_state=$(gh pr view "$pr" --json state -q '.state' 2>/dev/null || echo "")
   if [[ "$pr_state" != "MERGED" ]]; then
     err "  Failed to merge PR #${pr} (state: ${pr_state})"
+    emit_event ralph_merge_failed "$issue" \
+      "$(jq -nc --argjson pr "$pr" --arg s "$pr_state" \
+          '{pr:$pr, state:$s, reason:"not_merged"}')"
     return 1
   fi
+
+  emit_event ralph_merge_succeeded "$issue" \
+    "$(jq -nc --argjson pr "$pr" '{pr:$pr}')"
 
   # Sync local main so next worktree branches from updated code
   git fetch origin "$main" &>/dev/null

--- a/src/smart_ralph/ralph_client.py
+++ b/src/smart_ralph/ralph_client.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import json
+import os
 import subprocess
 import time
 from pathlib import Path
@@ -13,24 +13,17 @@ class RalphProcess:
         self._cwd = cwd
 
     def events(self) -> Iterator[dict[str, Any]]:
+        """Yield ralph's human-readable stdout wrapped as ralph_stdout events.
+
+        Structured events from ralph are written directly to the shared
+        .smart-ralph/events.jsonl by ralph itself (via lib/ralph-events.sh)
+        using the run_id the supervisor injects at spawn time, so there is
+        no in-memory merge step here.
+        """
         assert self._proc.stdout is not None
         for raw in self._proc.stdout:
             line = raw.rstrip("\n")
             yield {"type": "ralph_stdout", "payload": {"line": line}}
-        yield from self._replay_ralph_events()
-
-    def _replay_ralph_events(self) -> Iterator[dict[str, Any]]:
-        path = self._cwd / ".ralph" / "events.jsonl"
-        if not path.exists():
-            return
-        for line in path.read_text().splitlines():
-            if not line.strip():
-                continue
-            try:
-                parsed = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            yield {"type": "ralph_event", "payload": parsed}
 
     def wait(self) -> int:
         return self._proc.wait()
@@ -57,11 +50,26 @@ class RalphProcess:
 
 
 class RalphClient:
-    def __init__(self, ralph_path: Path, cwd: Path) -> None:
+    def __init__(
+        self,
+        ralph_path: Path,
+        cwd: Path,
+        *,
+        run_id: str | None = None,
+        events_path: Path | None = None,
+    ) -> None:
         self._ralph_path = Path(ralph_path)
         self._cwd = Path(cwd)
+        self._run_id = run_id
+        self._events_path = Path(events_path) if events_path is not None else None
 
     def spawn(self, issue: int) -> RalphProcess:
+        env = os.environ.copy()
+        if self._run_id is not None:
+            env["SMART_RALPH_RUN_ID"] = self._run_id
+        if self._events_path is not None:
+            env["SMART_RALPH_EVENTS_PATH"] = str(self._events_path)
+
         proc = subprocess.Popen(
             [str(self._ralph_path), str(issue)],
             cwd=self._cwd,
@@ -69,5 +77,6 @@ class RalphClient:
             stderr=subprocess.STDOUT,
             text=True,
             bufsize=1,
+            env=env,
         )
         return RalphProcess(proc, self._cwd)

--- a/src/smart_ralph/supervisor.py
+++ b/src/smart_ralph/supervisor.py
@@ -80,7 +80,12 @@ class Supervisor:
                 event_type="run_started", source="supervisor",
                 issue=issue, payload={}, sync=True,
             )
-            client = RalphClient(ralph_path=self._ralph_path, cwd=self._cwd)
+            client = RalphClient(
+                ralph_path=self._ralph_path,
+                cwd=self._cwd,
+                run_id=run_id,
+                events_path=meta_dir / "events.jsonl",
+            )
             process = client.spawn(issue=issue)
             log.append(
                 event_type="ralph_spawned", source="supervisor",

--- a/tests/fixtures/fake_ralph/echo_env.sh
+++ b/tests/fixtures/fake_ralph/echo_env.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Fake ralph that echoes the smart-ralph env vars so tests can assert
+# they were injected into the child process.
+set -euo pipefail
+echo "SMART_RALPH_RUN_ID=${SMART_RALPH_RUN_ID:-<unset>}"
+echo "SMART_RALPH_EVENTS_PATH=${SMART_RALPH_EVENTS_PATH:-<unset>}"

--- a/tests/fixtures/fake_ralph/writes_events.sh
+++ b/tests/fixtures/fake_ralph/writes_events.sh
@@ -1,11 +1,19 @@
 #!/usr/bin/env bash
-# Fake ralph that writes structured events to .ralph/events.jsonl
-# *while* also writing stdout lines. Mimics the real patched ralph.
+# Fake ralph that emits envelope-formatted structured events via the
+# real lib/ralph-events.sh helper, while also writing stdout. This is the
+# post-#6 shape: ralph writes DIRECTLY to .smart-ralph/events.jsonl
+# (using env vars the supervisor injects), not to a separate .ralph file.
 set -euo pipefail
-prd="${1:-?}"
-mkdir -p .ralph
+issue="${1:-?}"
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../../.." && pwd)"
+# shellcheck disable=SC1091
+source "$root/lib/ralph-events.sh"
+
 echo "ralph: iteration begin"
-printf '{"type":"ralph_iteration_started","payload":{"prd":"%s"}}\n' "$prd" >> .ralph/events.jsonl
+emit_event ralph_iteration_started "$issue" \
+  "$(jq -nc --argjson i 1 '{iteration:$i}')"
 echo "ralph: working"
-printf '{"type":"ralph_iteration_ended","payload":{"ok":true}}\n' >> .ralph/events.jsonl
+emit_event ralph_iteration_ended "$issue" \
+  "$(jq -nc --argjson i 1 --arg o "complete" '{iteration:$i, outcome:$o}')"
 echo "ralph: done"

--- a/tests/fixtures/fake_tools/claude
+++ b/tests/fixtures/fake_tools/claude
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Fake claude: emits a minimal stream-json completion with COMPLETE.
+# Accepts and ignores all flags; writes to stdout so ralph's pipe sees it.
+set -euo pipefail
+printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"doing work"}]}}'
+printf '%s\n' '{"type":"result","result":"<promise>COMPLETE</promise>"}'

--- a/tests/fixtures/fake_tools/gh
+++ b/tests/fixtures/fake_tools/gh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Fake gh: enough surface area for ralph's run/merge paths.
+# Env knobs:
+#   FAKE_GH_PR_NUMBER (default 99)    — number returned by `pr list`
+#   FAKE_GH_PR_STATE  (default MERGED) — state returned by `pr view`
+set -euo pipefail
+
+if [[ -n "${FAKE_GH_PR_NONE:-}" ]]; then
+  pr_num=""
+else
+  pr_num="${FAKE_GH_PR_NUMBER:-99}"
+fi
+pr_state="${FAKE_GH_PR_STATE:-MERGED}"
+
+sub="${1:-}"; shift || true
+action="${1:-}"; shift || true
+
+case "$sub" in
+  issue)
+    case "$action" in
+      view)
+        # Extract -q flag if present; ignore everything else.
+        while [[ $# -gt 0 ]]; do
+          case "$1" in
+            -q) shift; jq_filter="$1"; shift ;;
+            --jq) shift; jq_filter="$1"; shift ;;
+            *) shift ;;
+          esac
+        done
+        if [[ "${jq_filter:-}" == ".title" ]]; then
+          echo "Fake issue for tests"
+        else
+          echo '{"title":"Fake issue for tests"}'
+        fi
+        ;;
+      list)
+        echo '[]'
+        ;;
+      close)
+        : # silent success
+        ;;
+      *)
+        echo '{}'
+        ;;
+    esac
+    ;;
+  pr)
+    case "$action" in
+      list)
+        # ralph passes a complex -q filter that ultimately returns the PR number
+        # or empty. We short-circuit to $pr_num.
+        echo "$pr_num"
+        ;;
+      view)
+        while [[ $# -gt 0 ]]; do
+          case "$1" in
+            -q) shift; jq_filter="$1"; shift ;;
+            *) shift ;;
+          esac
+        done
+        if [[ "${jq_filter:-}" == ".state" ]]; then
+          echo "$pr_state"
+        else
+          echo "{\"state\":\"$pr_state\"}"
+        fi
+        ;;
+      merge|diff|comment)
+        : # silent success
+        ;;
+      *)
+        : ;;
+    esac
+    ;;
+  api)
+    echo '{}'
+    ;;
+  *)
+    : ;;
+esac

--- a/tests/test_ralph_client.py
+++ b/tests/test_ralph_client.py
@@ -18,6 +18,26 @@ def _init_repo(path: Path) -> None:
     )
 
 
+def test_spawn_injects_smart_ralph_env_vars(tmp_path):
+    events_path = tmp_path / ".smart-ralph" / "events.jsonl"
+    client = RalphClient(
+        ralph_path=FIXTURES / "echo_env.sh",
+        cwd=tmp_path,
+        run_id="run-xyz",
+        events_path=events_path,
+    )
+
+    process = client.spawn(issue=2)
+    events = list(process.events())
+    process.wait()
+
+    stdout_lines = [
+        e["payload"]["line"] for e in events if e["type"] == "ralph_stdout"
+    ]
+    assert f"SMART_RALPH_RUN_ID=run-xyz" in stdout_lines
+    assert f"SMART_RALPH_EVENTS_PATH={events_path}" in stdout_lines
+
+
 def test_spawn_yields_stdout_lines_as_events(tmp_path):
     client = RalphClient(
         ralph_path=FIXTURES / "echo_stdout.sh",
@@ -38,33 +58,44 @@ def test_spawn_yields_stdout_lines_as_events(tmp_path):
     ]
 
 
-def test_events_merges_ralph_events_jsonl(tmp_path):
+def test_ralph_structured_events_land_in_shared_events_jsonl(tmp_path):
+    """Post-#6: ralph writes structured events directly to the shared
+    .smart-ralph/events.jsonl using supervisor-injected env vars. Stdout is
+    still surfaced in-memory as ralph_stdout; structured events are not
+    duplicated into the in-memory stream."""
+    events_path = tmp_path / ".smart-ralph" / "events.jsonl"
     client = RalphClient(
         ralph_path=FIXTURES / "writes_events.sh",
         cwd=tmp_path,
+        run_id="run-shared",
+        events_path=events_path,
     )
 
     process = client.spawn(issue=7)
     events = list(process.events())
     process.wait()
 
-    # stdout events present
+    # stdout still surfaces in-memory
     stdout_lines = [
         e["payload"]["line"] for e in events if e["type"] == "ralph_stdout"
     ]
     assert stdout_lines == ["ralph: iteration begin", "ralph: working", "ralph: done"]
 
-    # ralph's own structured events are merged in as ralph_event
-    ralph_events = [e for e in events if e["type"] == "ralph_event"]
-    types = [e["payload"]["type"] for e in ralph_events]
-    assert types == ["ralph_iteration_started", "ralph_iteration_ended"]
-    assert ralph_events[0]["payload"]["payload"]["prd"] == "7"  # stub passes the raw arg
-    assert ralph_events[1]["payload"]["payload"]["ok"] is True
+    # Structured events are NOT duplicated into the in-memory stream.
+    assert not [e for e in events if e["type"].startswith("ralph_iteration")]
 
-    # sanity: .ralph/events.jsonl actually got written
-    written = (tmp_path / ".ralph" / "events.jsonl").read_text().splitlines()
-    assert len(written) == 2
-    assert json.loads(written[0])["type"] == "ralph_iteration_started"
+    # They are written directly to the shared events.jsonl with envelope shape.
+    entries = [
+        json.loads(line)
+        for line in events_path.read_text().splitlines() if line.strip()
+    ]
+    types = [e["type"] for e in entries]
+    assert types == ["ralph_iteration_started", "ralph_iteration_ended"]
+    for entry in entries:
+        assert entry["source"] == "ralph"
+        assert entry["run_id"] == "run-shared"
+        assert entry["issue"] == 7
+        assert entry["schema_version"] == 1
 
 
 def test_kill_terminates_process_and_stashes_uncommitted(tmp_path):

--- a/tests/test_ralph_events.py
+++ b/tests/test_ralph_events.py
@@ -1,0 +1,400 @@
+"""Tests for ralph's structured event emission (issue #6).
+
+Unit tests source lib/ralph-events.sh directly and call emit_event.
+Integration tests run the real ralph script with mocked claude/gh/git.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent
+LIB = ROOT / "lib" / "ralph-events.sh"
+RALPH = ROOT / "ralph"
+FAKE_TOOLS = Path(__file__).parent / "fixtures" / "fake_tools"
+
+
+def _init_repo(path: Path) -> None:
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=path, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit",
+         "--allow-empty", "-q", "-m", "init"],
+        cwd=path, check=True,
+    )
+
+
+def _run_ralph(
+    repo: Path,
+    args: list[str],
+    *,
+    run_id: str = "run-e2e",
+    events_path: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    events_path = events_path or (repo / ".smart-ralph" / "events.jsonl")
+    env = os.environ.copy()
+    env["PATH"] = f"{FAKE_TOOLS}:{env['PATH']}"
+    env["SMART_RALPH_RUN_ID"] = run_id
+    env["SMART_RALPH_EVENTS_PATH"] = str(events_path)
+    env["RALPH_ITERATIONS"] = "2"
+    return subprocess.run(
+        [str(RALPH), *args],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+
+def _emit(
+    tmp_path: Path,
+    event_type: str,
+    issue: str,
+    payload_json: str,
+    *,
+    run_id: str | None = "run-test-1",
+    events_path: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Invoke emit_event via a subshell that sources the helper lib."""
+    env = {"PATH": os.environ["PATH"]}
+    if run_id is not None:
+        env["SMART_RALPH_RUN_ID"] = run_id
+    if events_path is None:
+        events_path = tmp_path / ".smart-ralph" / "events.jsonl"
+    env["SMART_RALPH_EVENTS_PATH"] = str(events_path)
+
+    script = (
+        f"source {LIB} && "
+        f"emit_event {event_type} {issue!r} {payload_json!r}"
+    )
+    return subprocess.run(
+        ["bash", "-c", script],
+        env=env,
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+# ── Slice 1: envelope shape ────────────────────────────────
+
+def test_emit_event_writes_envelope_with_ralph_source(tmp_path):
+    result = _emit(
+        tmp_path,
+        "ralph_issue_started",
+        "42",
+        '{"title":"do the thing"}',
+    )
+    assert result.returncode == 0, result.stderr
+
+    events_path = tmp_path / ".smart-ralph" / "events.jsonl"
+    lines = events_path.read_text().splitlines()
+    assert len(lines) == 1
+
+    evt = json.loads(lines[0])
+    assert evt["schema_version"] == 1
+    assert evt["run_id"] == "run-test-1"
+    assert evt["type"] == "ralph_issue_started"
+    assert evt["source"] == "ralph"
+    assert evt["issue"] == 42
+    assert evt["payload"] == {"title": "do the thing"}
+    assert evt["ts"].endswith("Z")
+
+
+# ── Slice 2: no-op without env ────────────────────────────
+
+def test_emit_event_is_noop_when_run_id_unset(tmp_path):
+    events_path = tmp_path / ".smart-ralph" / "events.jsonl"
+    result = _emit(
+        tmp_path,
+        "ralph_issue_started",
+        "42",
+        "{}",
+        run_id=None,
+        events_path=events_path,
+    )
+    assert result.returncode == 0, result.stderr
+    assert not events_path.exists()
+    assert not events_path.parent.exists()
+
+
+# ── Slice 3: oversized payload → sidecar blob ─────────────
+
+def test_oversized_payload_written_to_blob_sidecar(tmp_path):
+    big_text = "x" * 5000  # forces the envelope past 4KB
+    payload_json = json.dumps({"log": big_text})
+
+    result = _emit(
+        tmp_path,
+        "ralph_error",
+        "9",
+        payload_json,
+    )
+    assert result.returncode == 0, result.stderr
+
+    events_path = tmp_path / ".smart-ralph" / "events.jsonl"
+    lines = events_path.read_text().splitlines()
+    assert len(lines) == 1
+
+    # Envelope line itself stays ≤4KB (including newline).
+    assert len(lines[0]) + 1 <= 4096
+
+    evt = json.loads(lines[0])
+    assert evt["type"] == "ralph_error"
+    assert evt["source"] == "ralph"
+    # Payload references a sidecar blob instead of carrying the data inline.
+    assert "blob_ref" in evt["payload"]
+    assert evt["payload"].get("oversized") is True
+
+    blob_rel = evt["payload"]["blob_ref"]
+    blob_path = tmp_path / blob_rel
+    assert blob_path.exists(), f"blob not at {blob_path}"
+    # The blob path should live under .smart-ralph/blobs/<run_id>/
+    assert ".smart-ralph/blobs/run-test-1/" in blob_rel
+    # Full original payload recoverable from the blob.
+    recovered = json.loads(blob_path.read_text())
+    assert recovered == {"log": big_text}
+
+
+# ── Slice 5: ralph emits issue + iteration + exit ─────────
+
+def _read_events(events_path: Path) -> list[dict]:
+    if not events_path.exists():
+        return []
+    out = []
+    for line in events_path.read_text().splitlines():
+        if line.strip():
+            out.append(json.loads(line))
+    return out
+
+
+def test_ralph_run_emits_issue_iteration_and_exit_events(tmp_path):
+    _init_repo(tmp_path)
+    events_path = tmp_path / ".smart-ralph" / "events.jsonl"
+
+    result = _run_ralph(tmp_path, ["run", "42", "1"], events_path=events_path)
+    assert result.returncode == 0, (
+        f"ralph failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+    events = _read_events(events_path)
+    types = [e["type"] for e in events]
+
+    assert "ralph_issue_started" in types
+    assert "ralph_iteration_started" in types
+    assert "ralph_iteration_ended" in types
+    assert "ralph_exit" in types
+
+    # Every ralph-emitted event has source: "ralph" and matching run_id.
+    for evt in events:
+        assert evt["source"] == "ralph"
+        assert evt["run_id"] == "run-e2e"
+        assert evt["schema_version"] == 1
+
+    # ralph_issue_started should reference the issue number
+    started = next(e for e in events if e["type"] == "ralph_issue_started")
+    assert started["issue"] == 42
+
+    # The iteration_started event that fired first carries iteration 1
+    iter_started = next(e for e in events if e["type"] == "ralph_iteration_started")
+    assert iter_started["payload"]["iteration"] == 1
+
+    # ralph_exit should be last and carry exit_code 0 (claude emitted COMPLETE)
+    assert types[-1] == "ralph_exit"
+    assert events[-1]["payload"]["exit_code"] == 0
+
+
+# ── Slice 6: state_transition + error events ──────────────
+
+def _source_ralph_and_run(
+    repo: Path,
+    snippet: str,
+    *,
+    run_id: str = "run-state",
+) -> subprocess.CompletedProcess[str]:
+    """Source ralph in a subshell so ralph's functions are callable directly."""
+    events_path = repo / ".smart-ralph" / "events.jsonl"
+    env = os.environ.copy()
+    env["PATH"] = f"{FAKE_TOOLS}:{env['PATH']}"
+    env["SMART_RALPH_RUN_ID"] = run_id
+    env["SMART_RALPH_EVENTS_PATH"] = str(events_path)
+    # Sourcing ralph without args hits the usage branch; that's harmless.
+    script = f"source '{RALPH}' >/dev/null 2>&1; set -e; {snippet}"
+    return subprocess.run(
+        ["bash", "-c", script],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_set_state_emits_ralph_state_transition(tmp_path):
+    _init_repo(tmp_path)
+    (tmp_path / ".ralph").mkdir()
+    (tmp_path / ".ralph" / "state.json").write_text(
+        '{"issues":{"42":"pending"}}'
+    )
+
+    result = _source_ralph_and_run(
+        tmp_path,
+        "set_state 42 in_progress; set_state 42 complete",
+    )
+    assert result.returncode == 0, result.stderr
+
+    events = _read_events(tmp_path / ".smart-ralph" / "events.jsonl")
+    transitions = [e for e in events if e["type"] == "ralph_state_transition"]
+    assert len(transitions) == 2
+
+    assert transitions[0]["issue"] == 42
+    assert transitions[0]["source"] == "ralph"
+    assert transitions[0]["payload"] == {"from": "pending", "to": "in_progress"}
+    assert transitions[1]["payload"] == {
+        "from": "in_progress", "to": "complete"
+    }
+
+
+def test_ralph_run_emits_ralph_error_on_iteration_exhaustion(tmp_path):
+    """When claude never emits COMPLETE, ralph must mark the failure as
+    a ralph_error so the supervisor can react."""
+    _init_repo(tmp_path)
+
+    # Override fake claude with one that never emits COMPLETE.
+    shim_dir = tmp_path / "shims"
+    shim_dir.mkdir()
+    claude_shim = shim_dir / "claude"
+    claude_shim.write_text(
+        '#!/usr/bin/env bash\n'
+        'printf \'%s\\n\' \'{"type":"result","result":"not done yet"}\'\n'
+    )
+    claude_shim.chmod(0o755)
+    # Copy fake gh alongside
+    import shutil as _shutil
+    _shutil.copy(FAKE_TOOLS / "gh", shim_dir / "gh")
+    (shim_dir / "gh").chmod(0o755)
+
+    events_path = tmp_path / ".smart-ralph" / "events.jsonl"
+    env = os.environ.copy()
+    env["PATH"] = f"{shim_dir}:{env['PATH']}"
+    env["SMART_RALPH_RUN_ID"] = "run-err"
+    env["SMART_RALPH_EVENTS_PATH"] = str(events_path)
+    env["RALPH_ITERATIONS"] = "1"
+
+    result = subprocess.run(
+        [str(RALPH), "run", "9", "1"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    # ralph exits 1 when iterations are exhausted without COMPLETE
+    assert result.returncode != 0, (
+        f"expected failure, got success. stdout:\n{result.stdout}"
+    )
+
+    events = _read_events(events_path)
+    errors = [e for e in events if e["type"] == "ralph_error"]
+    assert len(errors) >= 1, (
+        f"expected ralph_error event. events seen: {[e['type'] for e in events]}"
+    )
+    err_evt = errors[0]
+    assert err_evt["source"] == "ralph"
+    assert err_evt["issue"] == 9
+    assert "iterations_exhausted" in err_evt["payload"].get("reason", "")
+
+
+# ── Slice 7: merge events ─────────────────────────────────
+
+def test_merge_issue_success_emits_attempted_and_succeeded(tmp_path):
+    _init_repo(tmp_path)
+
+    result = _source_ralph_and_run(
+        tmp_path,
+        "merge_issue 7",
+        run_id="run-merge-ok",
+    )
+    # merge_issue may return non-zero because `gh issue close` path is noisy,
+    # but the events should still have been emitted.
+    events = _read_events(tmp_path / ".smart-ralph" / "events.jsonl")
+    types = [e["type"] for e in events]
+
+    assert "ralph_merge_attempted" in types, (
+        f"attempt missing. events: {types}. stderr:\n{result.stderr}"
+    )
+    assert "ralph_merge_succeeded" in types, (
+        f"success missing. events: {types}. stderr:\n{result.stderr}"
+    )
+
+    attempted = next(e for e in events if e["type"] == "ralph_merge_attempted")
+    assert attempted["issue"] == 7
+    assert attempted["source"] == "ralph"
+    assert attempted["payload"].get("pr") == 99
+
+    succeeded = next(e for e in events if e["type"] == "ralph_merge_succeeded")
+    assert succeeded["issue"] == 7
+    assert succeeded["payload"].get("pr") == 99
+
+
+def test_merge_issue_failure_emits_merge_failed(tmp_path):
+    _init_repo(tmp_path)
+    events_path = tmp_path / ".smart-ralph" / "events.jsonl"
+    env = os.environ.copy()
+    env["PATH"] = f"{FAKE_TOOLS}:{env['PATH']}"
+    env["SMART_RALPH_RUN_ID"] = "run-merge-bad"
+    env["SMART_RALPH_EVENTS_PATH"] = str(events_path)
+    env["FAKE_GH_PR_STATE"] = "OPEN"  # simulate merge didn't actually happen
+
+    script = f"source '{RALPH}' >/dev/null 2>&1; merge_issue 7 || true"
+    subprocess.run(
+        ["bash", "-c", script],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    events = _read_events(events_path)
+    types = [e["type"] for e in events]
+    assert "ralph_merge_attempted" in types
+    assert "ralph_merge_failed" in types
+    failed = next(e for e in events if e["type"] == "ralph_merge_failed")
+    assert failed["issue"] == 7
+    assert failed["payload"].get("pr") == 99
+    assert failed["payload"].get("state") == "OPEN"
+
+
+def test_merge_issue_no_pr_emits_merge_failed(tmp_path):
+    _init_repo(tmp_path)
+    events_path = tmp_path / ".smart-ralph" / "events.jsonl"
+    env = os.environ.copy()
+    env["PATH"] = f"{FAKE_TOOLS}:{env['PATH']}"
+    env["SMART_RALPH_RUN_ID"] = "run-merge-nopr"
+    env["SMART_RALPH_EVENTS_PATH"] = str(events_path)
+    env["FAKE_GH_PR_NONE"] = "1"  # simulate no open PR
+
+    script = f"source '{RALPH}' >/dev/null 2>&1; merge_issue 7 || true"
+    subprocess.run(
+        ["bash", "-c", script],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    events = _read_events(events_path)
+    types = [e["type"] for e in events]
+    assert "ralph_merge_failed" in types
+    failed = next(e for e in events if e["type"] == "ralph_merge_failed")
+    assert failed["issue"] == 7
+    assert failed["payload"].get("reason") == "no_pr_found"

--- a/tests/test_ralph_events.py
+++ b/tests/test_ralph_events.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -96,7 +97,8 @@ def test_helper_is_safe_to_source_twice(tmp_path):
         "SMART_RALPH_RUN_ID": "run-double",
         "SMART_RALPH_EVENTS_PATH": str(events_path),
     }
-    script = f"source {LIB} && source {LIB} && emit_event ralph_ping 1 '{{}}'"
+    # No payload arg — helper defaults to an empty object.
+    script = f"source {LIB} && source {LIB} && emit_event ralph_ping 1"
     result = subprocess.run(
         ["bash", "-c", script],
         env=env, cwd=tmp_path, capture_output=True, text=True, check=False,
@@ -219,6 +221,9 @@ def test_blob_filename_is_safe_under_bsd_date(tmp_path):
     shim.chmod(0o755)
 
     # Force bash-builtin timestamp path (no gdate, no GNU date detection).
+    # Resolve bash from the parent env first — the helper requires 4.2+
+    # (preflighted by ralph) and macOS ships /bin/bash 3.2.
+    bash_bin = shutil.which("bash") or "/bin/bash"
     payload_json = json.dumps({"log": "x" * 5000})
     events_path = tmp_path / ".smart-ralph" / "events.jsonl"
     env = {
@@ -229,7 +234,7 @@ def test_blob_filename_is_safe_under_bsd_date(tmp_path):
     }
     script = f"source {LIB} && emit_event ralph_error 9 {payload_json!r}"
     result = subprocess.run(
-        ["bash", "-c", script],
+        [bash_bin, "-c", script],
         env=env, cwd=tmp_path, capture_output=True, text=True, check=False,
     )
     assert result.returncode == 0, result.stderr

--- a/tests/test_ralph_events.py
+++ b/tests/test_ralph_events.py
@@ -153,13 +153,80 @@ def test_oversized_payload_written_to_blob_sidecar(tmp_path):
     assert evt["payload"].get("oversized") is True
 
     blob_rel = evt["payload"]["blob_ref"]
-    blob_path = tmp_path / blob_rel
+    # blob_ref is relative to events_root (the events.jsonl parent), so
+    # readers can resolve it without needing to know ralph's cwd.
+    events_root = (tmp_path / ".smart-ralph").resolve()
+    blob_path = events_root / blob_rel
     assert blob_path.exists(), f"blob not at {blob_path}"
-    # The blob path should live under .smart-ralph/blobs/<run_id>/
-    assert ".smart-ralph/blobs/run-test-1/" in blob_rel
+    assert blob_rel.startswith("blobs/run-test-1/"), blob_rel
     # Full original payload recoverable from the blob.
     recovered = json.loads(blob_path.read_text())
     assert recovered == {"log": big_text}
+
+
+def test_multibyte_payload_offloaded_when_bytes_exceed_4kb(tmp_path):
+    """Char count can understate size for multi-byte UTF-8 content.
+    The guard must count bytes so the atomicity window is never exceeded."""
+    # 1500 em-dashes = 1500 chars, 4500 UTF-8 bytes (3 per char).
+    # Well under 4096 chars, well over 4096 bytes.
+    payload_json = json.dumps({"log": "\u2014" * 1500}, ensure_ascii=False)
+    assert len(payload_json) < 4000  # char count below threshold
+    assert len(payload_json.encode("utf-8")) > 4096  # byte count above
+
+    result = _emit(
+        tmp_path,
+        "ralph_error",
+        "9",
+        payload_json,
+    )
+    assert result.returncode == 0, result.stderr
+
+    events_path = tmp_path / ".smart-ralph" / "events.jsonl"
+    line = events_path.read_text().splitlines()[0]
+
+    # The emitted envelope must fit in the atomicity window by BYTES.
+    assert len(line.encode("utf-8")) + 1 <= 4096, (
+        f"envelope line is {len(line.encode('utf-8')) + 1} bytes"
+    )
+
+    evt = json.loads(line)
+    assert "blob_ref" in evt["payload"]
+    assert evt["payload"].get("oversized") is True
+
+
+def test_non_integer_issue_coerced_to_null(tmp_path):
+    """Guard against malformed issue values reaching jq --argjson —
+    they must be coerced to null, not parsed as raw JSON."""
+    result = _emit(
+        tmp_path,
+        "ralph_issue_started",
+        "not-a-number",
+        "{}",
+    )
+    assert result.returncode == 0, result.stderr
+
+    events_path = tmp_path / ".smart-ralph" / "events.jsonl"
+    evt = json.loads(events_path.read_text().splitlines()[0])
+    assert evt["issue"] is None
+
+
+def test_missing_payload_defaults_to_empty_object(tmp_path):
+    """emit_event called with no payload argument must default to {}."""
+    events_path = tmp_path / ".smart-ralph" / "events.jsonl"
+    env = {
+        "PATH": os.environ["PATH"],
+        "SMART_RALPH_RUN_ID": "run-default",
+        "SMART_RALPH_EVENTS_PATH": str(events_path),
+    }
+    script = f"source {LIB} && emit_event ralph_issue_started 7"
+    result = subprocess.run(
+        ["bash", "-c", script],
+        env=env, cwd=tmp_path, capture_output=True, text=True, check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+    evt = json.loads(events_path.read_text().splitlines()[0])
+    assert evt["payload"] == {}
 
 
 # ── Slice 5: ralph emits issue + iteration + exit ─────────
@@ -189,7 +256,14 @@ def test_ralph_run_emits_issue_iteration_and_exit_events(tmp_path):
     assert "ralph_issue_started" in types
     assert "ralph_iteration_started" in types
     assert "ralph_iteration_ended" in types
+    assert "ralph_issue_ended" in types
     assert "ralph_exit" in types
+
+    # Success path must close the issue with outcome=complete (symmetric
+    # with the iterations-exhausted path).
+    issue_ended = next(e for e in events if e["type"] == "ralph_issue_ended")
+    assert issue_ended["payload"]["outcome"] == "complete"
+    assert issue_ended["payload"]["iterations"] == 1
 
     # Every ralph-emitted event has source: "ralph" and matching run_id.
     for evt in events:
@@ -310,6 +384,12 @@ def test_ralph_run_emits_ralph_error_on_iteration_exhaustion(tmp_path):
     assert err_evt["source"] == "ralph"
     assert err_evt["issue"] == 9
     assert "iterations_exhausted" in err_evt["payload"].get("reason", "")
+
+    # ralph_exit must carry the non-zero exit code so supervisor readers
+    # can distinguish failure from success without re-deriving it.
+    exit_events = [e for e in events if e["type"] == "ralph_exit"]
+    assert len(exit_events) == 1
+    assert exit_events[0]["payload"]["exit_code"] != 0
 
 
 # ── Slice 7: merge events ─────────────────────────────────

--- a/tests/test_ralph_events.py
+++ b/tests/test_ralph_events.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 from pathlib import Path
 
@@ -163,7 +164,6 @@ def test_oversized_payload_written_to_blob_sidecar(tmp_path):
     # Filename must be shell/filesystem-safe on every platform — BSD `date`
     # silently outputs the literal string "%N" when asked for nanoseconds,
     # which would leak a "%" character into the blob path.
-    import re
     blob_basename = blob_path.name
     assert re.fullmatch(r"[A-Za-z0-9._-]+", blob_basename), (
         f"unsafe blob filename: {blob_basename!r}"
@@ -200,6 +200,7 @@ def test_blob_filename_is_safe_under_bsd_date(tmp_path):
     events_path = tmp_path / ".smart-ralph" / "events.jsonl"
     env = {
         "PATH": f"{shim_dir}:/usr/bin:/bin",  # shim first, no gdate available
+        "LC_ALL": "C",  # keep jq/wc/bash behavior deterministic under the shim
         "SMART_RALPH_RUN_ID": "run-bsd",
         "SMART_RALPH_EVENTS_PATH": str(events_path),
     }

--- a/tests/test_ralph_events.py
+++ b/tests/test_ralph_events.py
@@ -159,9 +159,61 @@ def test_oversized_payload_written_to_blob_sidecar(tmp_path):
     blob_path = events_root / blob_rel
     assert blob_path.exists(), f"blob not at {blob_path}"
     assert blob_rel.startswith("blobs/run-test-1/"), blob_rel
+
+    # Filename must be shell/filesystem-safe on every platform — BSD `date`
+    # silently outputs the literal string "%N" when asked for nanoseconds,
+    # which would leak a "%" character into the blob path.
+    import re
+    blob_basename = blob_path.name
+    assert re.fullmatch(r"[A-Za-z0-9._-]+", blob_basename), (
+        f"unsafe blob filename: {blob_basename!r}"
+    )
+
     # Full original payload recoverable from the blob.
     recovered = json.loads(blob_path.read_text())
     assert recovered == {"log": big_text}
+
+
+def test_blob_filename_is_safe_under_bsd_date(tmp_path):
+    """BSD `date` (macOS default) emits the literal string "%N" when asked
+    for nanoseconds. The blob filename must never contain a "%" — otherwise
+    it leaks into paths, URLs, and shell globs in unpredictable ways."""
+    # Shim `date` so any format string containing %N emits `<seconds>%N`
+    # verbatim, exactly the way BSD date behaves on unmodified macOS.
+    shim_dir = tmp_path / "bsd-date-shim"
+    shim_dir.mkdir()
+    shim = shim_dir / "date"
+    shim.write_text(
+        '#!/usr/bin/env bash\n'
+        '# BSD-date mimic: any %N token prints literally.\n'
+        'for a in "$@"; do\n'
+        '  case "$a" in\n'
+        '    *%N*) echo "$(/bin/date -u +%s)%N" ; exit 0 ;;\n'
+        '  esac\n'
+        'done\n'
+        'exec /bin/date "$@"\n'
+    )
+    shim.chmod(0o755)
+
+    # Force bash-builtin timestamp path (no gdate, no GNU date detection).
+    payload_json = json.dumps({"log": "x" * 5000})
+    events_path = tmp_path / ".smart-ralph" / "events.jsonl"
+    env = {
+        "PATH": f"{shim_dir}:/usr/bin:/bin",  # shim first, no gdate available
+        "SMART_RALPH_RUN_ID": "run-bsd",
+        "SMART_RALPH_EVENTS_PATH": str(events_path),
+    }
+    script = f"source {LIB} && emit_event ralph_error 9 {payload_json!r}"
+    result = subprocess.run(
+        ["bash", "-c", script],
+        env=env, cwd=tmp_path, capture_output=True, text=True, check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+    evt = json.loads(events_path.read_text().splitlines()[0])
+    blob_rel = evt["payload"]["blob_ref"]
+    assert "%" not in blob_rel, f"blob filename leaked literal %N: {blob_rel}"
+    assert (tmp_path / ".smart-ralph" / blob_rel).exists()
 
 
 def test_multibyte_payload_offloaded_when_bytes_exceed_4kb(tmp_path):

--- a/tests/test_ralph_events.py
+++ b/tests/test_ralph_events.py
@@ -85,6 +85,29 @@ def _emit(
 
 # ── Slice 1: envelope shape ────────────────────────────────
 
+def test_helper_is_safe_to_source_twice(tmp_path):
+    """The helper advertises itself as sourceable. Wrappers that source
+    it more than once (e.g., a shell that sources ralph and then the
+    helper directly) must not hit 'readonly variable' errors on the
+    second source."""
+    events_path = tmp_path / ".smart-ralph" / "events.jsonl"
+    env = {
+        "PATH": os.environ["PATH"],
+        "SMART_RALPH_RUN_ID": "run-double",
+        "SMART_RALPH_EVENTS_PATH": str(events_path),
+    }
+    script = f"source {LIB} && source {LIB} && emit_event ralph_ping 1 '{{}}'"
+    result = subprocess.run(
+        ["bash", "-c", script],
+        env=env, cwd=tmp_path, capture_output=True, text=True, check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    # No 'readonly variable' complaint on stderr.
+    assert "readonly" not in result.stderr.lower(), result.stderr
+    # Emit still works after double-source.
+    assert events_path.read_text().strip().startswith("{")
+
+
 def test_emit_event_writes_envelope_with_ralph_source(tmp_path):
     result = _emit(
         tmp_path,

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -232,6 +232,41 @@ def test_retention_prunes_old_runs_on_startup(tmp_path):
     assert "run_ended" in current_types
 
 
+def test_supervisor_and_ralph_share_events_jsonl(tmp_path):
+    """Supervisor and the patched ralph must share .smart-ralph/events.jsonl.
+    Both sources' events must be present, each with its own `source` tag and
+    matching run_id."""
+    _init_repo(tmp_path)
+    supervisor = Supervisor(
+        ralph_path=FIXTURES / "writes_events.sh",
+        cwd=tmp_path,
+        required_tools=_all_tools_present(),
+    )
+
+    supervisor.run(issue=55)
+
+    events_path = tmp_path / ".smart-ralph" / "events.jsonl"
+    assert events_path.exists()
+    entries = [json.loads(line) for line in events_path.read_text().splitlines()]
+
+    sources = {e["source"] for e in entries}
+    assert "supervisor" in sources
+    assert "ralph" in sources
+
+    # All events must carry the same run_id (supervisor-assigned).
+    run_ids = {e["run_id"] for e in entries}
+    assert len(run_ids) == 1, (
+        f"supervisor and ralph events must share run_id, got {run_ids}"
+    )
+
+    # Ralph-source events carry issue=55 (propagated from the spawn call).
+    ralph_events = [e for e in entries if e["source"] == "ralph"]
+    assert ralph_events, "expected at least one ralph-source event"
+    ralph_types = [e["type"] for e in ralph_events]
+    assert "ralph_iteration_started" in ralph_types
+    assert "ralph_iteration_ended" in ralph_types
+
+
 def test_kill_exception_on_sigint_is_logged_as_repair_failed(tmp_path):
     """If RalphClient.kill raises during SIGINT, the failure must be audit-logged
     (not silently swallowed) and the run must still exit cleanly."""


### PR DESCRIPTION
## Summary

- Ralph writes envelope-shaped events (`source: "ralph"`) directly to the shared `.smart-ralph/events.jsonl`, using a `run_id` + events path injected by the supervisor via env vars. One log, POSIX O_APPEND atomicity, both writers coexist.
- New sourceable helper at `lib/ralph-events.sh`. Env-gated: `SMART_RALPH_RUN_ID` unset → silent no-op, so standalone ralph invocations keep working.
- Emission covers issue start/end, iteration start/end, state transitions (via `set_state`), iteration-exhaustion errors, merge attempted/succeeded/failed, and a trap-driven `ralph_exit` that captures the final exit code on any exit path.
- Oversized payloads (>4KB line) are offloaded to a sidecar blob at `.smart-ralph/blobs/<run_id>/…`, with `payload.blob_ref` on the envelope so concurrent append writes stay inside the PIPE_BUF atomicity window.
- Human-readable stdout is untouched. The obsolete in-memory `.ralph/events.jsonl` replay path is retired since structured events now live on disk in the shared file.

Closes #6.

## Test plan

All 33 tests pass (`.venv/bin/python -m pytest`). New coverage in `tests/test_ralph_events.py` (9 tests) and `tests/test_supervisor.py::test_supervisor_and_ralph_share_events_jsonl`:

- [x] `emit_event` writes a valid envelope with `source: "ralph"`
- [x] `emit_event` is a silent no-op when `SMART_RALPH_RUN_ID` is unset
- [x] Oversized payloads offloaded to sidecar blob; envelope line stays ≤4KB
- [x] `RalphClient.spawn` injects `SMART_RALPH_RUN_ID` and `SMART_RALPH_EVENTS_PATH` into ralph's environment
- [x] End-to-end `./ralph run <N>` with mocked `claude`/`gh` on PATH produces `ralph_issue_started` → `ralph_iteration_started` → `ralph_iteration_ended` → `ralph_exit`
- [x] `set_state` emits `ralph_state_transition` with `{from, to}`
- [x] Iteration exhaustion emits `ralph_error` with `reason: "iterations_exhausted"`
- [x] `merge_issue` success path emits `ralph_merge_attempted` + `ralph_merge_succeeded`
- [x] `merge_issue` non-MERGED state emits `ralph_merge_failed` with `state` + `reason`
- [x] `merge_issue` with no open PR emits `ralph_merge_failed` with `reason: "no_pr_found"`
- [x] Supervisor + ralph events interleave in one `.smart-ralph/events.jsonl` with a shared `run_id` and distinct `source` tags

## Manual verification

- [ ] Run `./smart-ralph <issue>` against a live PRD and tail `.smart-ralph/events.jsonl` — confirm both `source: "supervisor"` and `source: "ralph"` events appear with matching `run_id`
- [ ] Run `./ralph <prd>` standalone (no supervisor env) and confirm no events file is created