### PR TITLE
Add AnomalyDetector with ralph_nonzero_exit rule (#7)

### DIFF
--- a/src/smart_ralph/anomaly.py
+++ b/src/smart_ralph/anomaly.py
@@ -1,0 +1,72 @@
+"""Real-time anomaly detection over the supervisor's event stream.
+
+The detector is stateful: it observes every event the supervisor sees,
+accumulates short-lived context (e.g., a bounded stdout tail), and runs
+registered rules. Rules are callables of (event, context) -> Anomaly | None.
+"""
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any, Callable, Deque
+
+Event = dict[str, Any]
+
+
+@dataclass(frozen=True)
+class Anomaly:
+    rule: str
+    issue: int | None = None
+    evidence: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class Context:
+    """Read-only snapshot of detector state passed to rules."""
+    log_tail: list[str]
+
+
+Rule = Callable[[Event, Context], "Anomaly | None"]
+
+
+# Exit codes that are normal lifecycle outcomes, not anomalies:
+#   0   — success
+#   42  — Claude rate limit (handled by a dedicated rule)
+#   130 — SIGINT, user-initiated shutdown
+_NORMAL_EXIT_CODES = frozenset({0, 42, 130})
+
+LOG_TAIL_MAX_LINES = 100
+
+
+def _ralph_nonzero_exit(event: Event, context: Context) -> Anomaly | None:
+    if event.get("type") != "ralph_exited":
+        return None
+    exit_code = event.get("payload", {}).get("exit_code")
+    if not isinstance(exit_code, int) or exit_code in _NORMAL_EXIT_CODES:
+        return None
+    return Anomaly(
+        rule="ralph_nonzero_exit",
+        issue=event.get("issue"),
+        evidence={
+            "exit_code": exit_code,
+            "log_tail": list(context.log_tail),
+        },
+    )
+
+
+class AnomalyDetector:
+    def __init__(self) -> None:
+        self._rules: list[Rule] = [_ralph_nonzero_exit]
+        self._log_tail: Deque[str] = deque(maxlen=LOG_TAIL_MAX_LINES)
+
+    def register(self, rule: Rule) -> None:
+        self._rules.append(rule)
+
+    def observe(self, event: Event) -> list[Anomaly]:
+        if event.get("type") == "ralph_stdout":
+            line = event.get("payload", {}).get("line")
+            if isinstance(line, str):
+                self._log_tail.append(line)
+
+        context = Context(log_tail=list(self._log_tail))
+        return [a for rule in self._rules if (a := rule(event, context)) is not None]

--- a/src/smart_ralph/anomaly.py
+++ b/src/smart_ralph/anomaly.py
@@ -35,7 +35,9 @@ Rule = Callable[[Event, Context], "Anomaly | None"]
 #   130 — SIGINT, user-initiated shutdown
 _NORMAL_EXIT_CODES = frozenset({0, 42, 130})
 
-LOG_TAIL_MAX_LINES = 100
+# Internal — the bounded stdout tail size is an implementation detail of
+# the detector's evidence collection, not a public knob.
+_LOG_TAIL_MAX_LINES = 100
 
 
 def _ralph_nonzero_exit(event: Event, context: Context) -> Anomaly | None:
@@ -57,7 +59,7 @@ def _ralph_nonzero_exit(event: Event, context: Context) -> Anomaly | None:
 class AnomalyDetector:
     def __init__(self) -> None:
         self._rules: list[Rule] = [_ralph_nonzero_exit]
-        self._log_tail: Deque[str] = deque(maxlen=LOG_TAIL_MAX_LINES)
+        self._log_tail: Deque[str] = deque(maxlen=_LOG_TAIL_MAX_LINES)
 
     def register(self, rule: Rule) -> None:
         self._rules.append(rule)

--- a/src/smart_ralph/dashboard.py
+++ b/src/smart_ralph/dashboard.py
@@ -49,7 +49,9 @@ class Dashboard:
             top_lines.append(f"[bold red]ANOMALY:[/bold red] {rule}")
         top_body = "\n".join(top_lines)
         bottom_body = "\n".join(state["stdout_tail"]) or "(no output yet)"
-        # Panel needs room for the content rows + 2 border rows + 1 padding row.
+        # +2 for the panel's top/bottom borders, +1 empirical buffer for
+        # the trailing whitespace Rich emits when the panel is shorter than
+        # the layout slot.
         top_size = len(top_lines) + 3
         layout = Layout()
         layout.split_column(

--- a/src/smart_ralph/dashboard.py
+++ b/src/smart_ralph/dashboard.py
@@ -49,8 +49,8 @@ class Dashboard:
             top_lines.append(f"[bold red]ANOMALY:[/bold red] {rule}")
         top_body = "\n".join(top_lines)
         bottom_body = "\n".join(state["stdout_tail"]) or "(no output yet)"
-        # Make room for the optional anomaly row.
-        top_size = 7 if state["anomaly"] is not None else 6
+        # Panel needs room for the content rows + 2 border rows + 1 padding row.
+        top_size = len(top_lines) + 3
         layout = Layout()
         layout.split_column(
             Layout(Panel(top_body, title="Progress"), size=top_size),

--- a/src/smart_ralph/dashboard.py
+++ b/src/smart_ralph/dashboard.py
@@ -39,15 +39,21 @@ class Dashboard:
     def _render_attached(self, events: list[dict[str, Any]]) -> None:
         state = _derive_state(events)
         console = Console(file=self._stream, force_terminal=True, width=80)
-        top_body = (
-            f"Issue: {state['issue']}\n"
-            f"Status: {state['status']}\n"
-            f"Ralph PID: {state['pid']}"
-        )
+        top_lines = [
+            f"Issue: {state['issue']}",
+            f"Status: {state['status']}",
+            f"Ralph PID: {state['pid']}",
+        ]
+        if state["anomaly"] is not None:
+            rule = state["anomaly"]["rule"]
+            top_lines.append(f"[bold red]ANOMALY:[/bold red] {rule}")
+        top_body = "\n".join(top_lines)
         bottom_body = "\n".join(state["stdout_tail"]) or "(no output yet)"
+        # Make room for the optional anomaly row.
+        top_size = 7 if state["anomaly"] is not None else 6
         layout = Layout()
         layout.split_column(
-            Layout(Panel(top_body, title="Progress"), size=6),
+            Layout(Panel(top_body, title="Progress"), size=top_size),
             Layout(Panel(bottom_body, title="Ralph output")),
         )
         console.print(layout)
@@ -69,6 +75,7 @@ def _derive_state(events: list[dict[str, Any]]) -> dict[str, Any]:
     pid: Any = None
     status = "pending"
     stdout_tail: list[str] = []
+    anomaly: dict[str, Any] | None = None
     for evt in events:
         etype = evt.get("type")
         payload = evt.get("payload", {})
@@ -85,9 +92,14 @@ def _derive_state(events: list[dict[str, Any]]) -> dict[str, Any]:
         elif etype == "ralph_stdout":
             line = payload.get("line", "")
             stdout_tail.append(line)
+        elif etype == "anomaly_detected":
+            # Latest anomaly wins — operator only needs to see the most
+            # recent one in the status line.
+            anomaly = {"rule": payload.get("rule", "?")}
     return {
         "issue": issue if issue is not None else "?",
         "pid": pid if pid is not None else "?",
         "status": status,
         "stdout_tail": stdout_tail[-10:],
+        "anomaly": anomaly,
     }

--- a/src/smart_ralph/eventlog.py
+++ b/src/smart_ralph/eventlog.py
@@ -54,13 +54,25 @@ class EventLog:
 
     def _offload_payload(self, payload: dict[str, Any]) -> dict[str, Any]:
         """Write payload to a blob under blobs/<run_id>/ and return a tiny
-        replacement payload that references it via blob_ref."""
+        replacement payload that references it via blob_ref.
+
+        The Python writer uses uuid4 hex for filenames; the bash writer in
+        lib/ralph-events.sh uses <ts_digits>-<pid>-<random>.json because
+        bash needs platform-portable name uniqueness without a uuid library.
+        Both schemes produce unique paths inside the same blobs/<run_id>/
+        directory; readers should not parse the filename.
+        """
         events_root = self._path.parent
         blob_dir = events_root / "blobs" / self._run_id
         blob_dir.mkdir(parents=True, exist_ok=True)
         blob_name = f"{uuid.uuid4().hex}.json"
         blob_path = blob_dir / blob_name
-        blob_path.write_text(json.dumps(payload, separators=(",", ":")))
+        # Atomic write: stage to a sibling .tmp file, fsync, then rename.
+        # Prevents readers from seeing a truncated blob if we crash between
+        # opening the file and finishing the write.
+        tmp_path = blob_path.with_suffix(blob_path.suffix + ".tmp")
+        tmp_path.write_text(json.dumps(payload, separators=(",", ":")))
+        os.replace(tmp_path, blob_path)
         # Path is relative to events_root so readers can resolve it without
         # needing to know the writer's cwd.
         return {"oversized": True, "blob_ref": f"blobs/{self._run_id}/{blob_name}"}

--- a/src/smart_ralph/eventlog.py
+++ b/src/smart_ralph/eventlog.py
@@ -2,11 +2,17 @@ from __future__ import annotations
 
 import json
 import os
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 SCHEMA_VERSION = 1
+
+# POSIX guarantees atomic appends only up to PIPE_BUF (typically 4096).
+# Lines that would exceed this window have their payload offloaded to a
+# sidecar blob, mirroring lib/ralph-events.sh on the bash side.
+_PIPE_BUF_BYTES = 4096
 
 
 class EventLog:
@@ -34,6 +40,10 @@ class EventLog:
             "payload": payload,
         }
         line = json.dumps(envelope, separators=(",", ":")) + "\n"
+        if len(line.encode("utf-8")) > _PIPE_BUF_BYTES:
+            envelope["payload"] = self._offload_payload(payload)
+            line = json.dumps(envelope, separators=(",", ":")) + "\n"
+
         fd = os.open(self._path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
         try:
             os.write(fd, line.encode("utf-8"))
@@ -41,6 +51,19 @@ class EventLog:
                 os.fsync(fd)
         finally:
             os.close(fd)
+
+    def _offload_payload(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Write payload to a blob under blobs/<run_id>/ and return a tiny
+        replacement payload that references it via blob_ref."""
+        events_root = self._path.parent
+        blob_dir = events_root / "blobs" / self._run_id
+        blob_dir.mkdir(parents=True, exist_ok=True)
+        blob_name = f"{uuid.uuid4().hex}.json"
+        blob_path = blob_dir / blob_name
+        blob_path.write_text(json.dumps(payload, separators=(",", ":")))
+        # Path is relative to events_root so readers can resolve it without
+        # needing to know the writer's cwd.
+        return {"oversized": True, "blob_ref": f"blobs/{self._run_id}/{blob_name}"}
 
     def prune_runs(self, keep: int) -> None:
         if not self._path.exists():

--- a/src/smart_ralph/eventlog.py
+++ b/src/smart_ralph/eventlog.py
@@ -67,9 +67,11 @@ class EventLog:
         blob_dir.mkdir(parents=True, exist_ok=True)
         blob_name = f"{uuid.uuid4().hex}.json"
         blob_path = blob_dir / blob_name
-        # Atomic write: stage to a sibling .tmp file, fsync, then rename.
-        # Prevents readers from seeing a truncated blob if we crash between
-        # opening the file and finishing the write.
+        # Atomic visibility: stage to a sibling .tmp file, then rename.
+        # The rename only succeeds after the write completes, so readers
+        # never observe a partially-written blob. (Power-loss durability
+        # would additionally require fsync of the file and parent dir;
+        # not in scope for v1.)
         tmp_path = blob_path.with_suffix(blob_path.suffix + ".tmp")
         tmp_path.write_text(json.dumps(payload, separators=(",", ":")))
         os.replace(tmp_path, blob_path)

--- a/src/smart_ralph/supervisor.py
+++ b/src/smart_ralph/supervisor.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import os
 import shutil
 import uuid
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 from smart_ralph.anomaly import Anomaly, AnomalyDetector
 from smart_ralph.eventlog import EventLog
@@ -37,17 +37,19 @@ class Supervisor:
         required_tools: list[str],
         retention_runs: int = 50,
         *,
-        detector: AnomalyDetector | None = None,
+        detector_factory: Callable[[], AnomalyDetector] = AnomalyDetector,
     ) -> None:
         self._ralph_path = Path(ralph_path)
         self._cwd = Path(cwd)
         self._required_tools = required_tools
         self._retention_runs = retention_runs
-        # Optional dependency injection for tests; default constructs the
-        # standard detector with the v1 built-in rule set.
-        self._detector_factory: Callable[[], AnomalyDetector] = (
-            (lambda: detector) if detector is not None else AnomalyDetector
-        )
+        # A factory (not an instance) is injected so each run() gets a
+        # fresh detector. This avoids state leaking — the bounded log_tail
+        # or any per-rule counters — across repeated runs on the same
+        # Supervisor instance. Callers that want shared state across runs
+        # can pass a factory that returns the same instance, but they opt
+        # in explicitly.
+        self._detector_factory = detector_factory
 
     def run(self, issue: int) -> tuple[int, list[dict]]:
         if not isinstance(issue, int) or issue <= 0:

--- a/src/smart_ralph/supervisor.py
+++ b/src/smart_ralph/supervisor.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import uuid
 from pathlib import Path
+from typing import Callable
 
 from smart_ralph.anomaly import Anomaly, AnomalyDetector
 from smart_ralph.eventlog import EventLog
@@ -35,11 +36,18 @@ class Supervisor:
         cwd: Path,
         required_tools: list[str],
         retention_runs: int = 50,
+        *,
+        detector: AnomalyDetector | None = None,
     ) -> None:
         self._ralph_path = Path(ralph_path)
         self._cwd = Path(cwd)
         self._required_tools = required_tools
         self._retention_runs = retention_runs
+        # Optional dependency injection for tests; default constructs the
+        # standard detector with the v1 built-in rule set.
+        self._detector_factory: Callable[[], AnomalyDetector] = (
+            (lambda: detector) if detector is not None else AnomalyDetector
+        )
 
     def run(self, issue: int) -> tuple[int, list[dict]]:
         if not isinstance(issue, int) or issue <= 0:
@@ -72,7 +80,7 @@ class Supervisor:
         run_id = uuid.uuid4().hex[:16]
         log = EventLog(meta_dir / "events.jsonl", run_id=run_id)
         log.prune_runs(keep=self._retention_runs)
-        detector = AnomalyDetector()
+        detector = self._detector_factory()
         process = None
         exit_code = 1
         events: list[dict] = []

--- a/src/smart_ralph/supervisor.py
+++ b/src/smart_ralph/supervisor.py
@@ -105,7 +105,7 @@ class Supervisor:
             events = []
             for evt in process.events():
                 events.append(evt)
-                detector.observe(evt)
+                _record_anomalies(detector.observe(evt))
             exit_code = process.wait()
             ralph_exited_event = {
                 "type": "ralph_exited",

--- a/src/smart_ralph/supervisor.py
+++ b/src/smart_ralph/supervisor.py
@@ -5,6 +5,7 @@ import shutil
 import uuid
 from pathlib import Path
 
+from smart_ralph.anomaly import Anomaly, AnomalyDetector
 from smart_ralph.eventlog import EventLog
 from smart_ralph.ralph_client import RalphClient
 
@@ -71,9 +72,19 @@ class Supervisor:
         run_id = uuid.uuid4().hex[:16]
         log = EventLog(meta_dir / "events.jsonl", run_id=run_id)
         log.prune_runs(keep=self._retention_runs)
+        detector = AnomalyDetector()
         process = None
         exit_code = 1
         events: list[dict] = []
+
+        def _record_anomalies(anomalies: list[Anomaly]) -> None:
+            for a in anomalies:
+                log.append(
+                    event_type="anomaly_detected", source="supervisor",
+                    issue=a.issue,
+                    payload={"rule": a.rule, "evidence": a.evidence},
+                    sync=True,
+                )
 
         try:
             log.append(
@@ -91,12 +102,21 @@ class Supervisor:
                 event_type="ralph_spawned", source="supervisor",
                 issue=issue, payload={"pid": process.pid}, sync=True,
             )
-            events = list(process.events())
+            events = []
+            for evt in process.events():
+                events.append(evt)
+                detector.observe(evt)
             exit_code = process.wait()
+            ralph_exited_event = {
+                "type": "ralph_exited",
+                "issue": issue,
+                "payload": {"exit_code": exit_code},
+            }
             log.append(
                 event_type="ralph_exited", source="supervisor",
                 issue=issue, payload={"exit_code": exit_code}, sync=True,
             )
+            _record_anomalies(detector.observe(ralph_exited_event))
             return exit_code, events
         except KeyboardInterrupt:
             if process is not None:

--- a/src/smart_ralph/supervisor.py
+++ b/src/smart_ralph/supervisor.py
@@ -29,6 +29,14 @@ def _pid_alive(pid: int) -> bool:
     return True
 
 
+def _default_detector_factory() -> AnomalyDetector:
+    """Default factory used by Supervisor when no detector_factory is
+    injected. A named function (rather than the class itself) keeps the
+    Callable[[], AnomalyDetector] type literal under strict type checkers
+    that distinguish type[AnomalyDetector] from a no-arg callable."""
+    return AnomalyDetector()
+
+
 class Supervisor:
     def __init__(
         self,
@@ -37,7 +45,7 @@ class Supervisor:
         required_tools: list[str],
         retention_runs: int = 50,
         *,
-        detector_factory: Callable[[], AnomalyDetector] = AnomalyDetector,
+        detector_factory: Callable[[], AnomalyDetector] = _default_detector_factory,
     ) -> None:
         self._ralph_path = Path(ralph_path)
         self._cwd = Path(cwd)

--- a/tests/fixtures/fake_ralph/exits_nonzero.sh
+++ b/tests/fixtures/fake_ralph/exits_nonzero.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Fake ralph that prints a few stdout lines and exits 1.
+# Used to verify the supervisor's anomaly-detection path.
+set -euo pipefail
+echo "ralph: starting"
+echo "ralph: doing work"
+echo "ralph: hitting an error"
+exit 1

--- a/tests/test_anomaly.py
+++ b/tests/test_anomaly.py
@@ -1,0 +1,98 @@
+"""Tests for AnomalyDetector (issue #7).
+
+The detector observes lifecycle events and returns Anomaly records. Rules
+are pluggable; the v1 default rule set fires on ralph non-zero exits
+(excluding 42 = rate limit and 130 = SIGINT).
+"""
+from __future__ import annotations
+
+from smart_ralph.anomaly import AnomalyDetector
+
+
+def _ralph_exited(exit_code: int, issue: int = 7) -> dict:
+    """Build a ralph_exited envelope event the way the supervisor writes it."""
+    return {
+        "schema_version": 1,
+        "ts": "2026-05-04T00:00:00.000Z",
+        "run_id": "run-test",
+        "type": "ralph_exited",
+        "source": "supervisor",
+        "issue": issue,
+        "payload": {"exit_code": exit_code},
+    }
+
+
+# ── Slice 1: tracer ────────────────────────────────────────
+
+def test_observe_emits_anomaly_for_nonzero_exit():
+    detector = AnomalyDetector()
+
+    anomalies = detector.observe(_ralph_exited(exit_code=1))
+
+    assert len(anomalies) == 1
+    assert anomalies[0].rule == "ralph_nonzero_exit"
+
+
+# ── Slice 2: exclude 0, 42, 130 ────────────────────────────
+
+def test_normal_exit_codes_do_not_trigger_anomaly():
+    """Exit 0 = success. 42 = rate limit (handled by its own rule path).
+    130 = SIGINT (user-initiated, not an anomaly)."""
+    detector = AnomalyDetector()
+
+    for code in (0, 42, 130):
+        assert detector.observe(_ralph_exited(exit_code=code)) == [], (
+            f"exit_code={code} should not trigger ralph_nonzero_exit"
+        )
+
+
+# ── Slice 3: evidence carries exit_code ────────────────────
+
+def test_anomaly_evidence_carries_exit_code():
+    detector = AnomalyDetector()
+
+    anomaly = detector.observe(_ralph_exited(exit_code=44))[0]
+
+    assert anomaly.evidence["exit_code"] == 44
+    assert anomaly.issue == 7
+
+
+# ── Slice 4: evidence carries log_tail ─────────────────────
+
+def _ralph_stdout(line: str) -> dict:
+    return {
+        "schema_version": 1,
+        "ts": "2026-05-04T00:00:00.000Z",
+        "run_id": "run-test",
+        "type": "ralph_stdout",
+        "source": "supervisor",
+        "issue": 7,
+        "payload": {"line": line},
+    }
+
+
+def test_anomaly_evidence_carries_last_100_log_lines():
+    """Detector accumulates ralph_stdout events into a bounded buffer.
+    On ralph_exited, the nonzero-exit rule snapshots the last 100 lines
+    into evidence.log_tail."""
+    detector = AnomalyDetector()
+
+    # Feed 150 stdout lines — only the trailing 100 should survive.
+    for i in range(150):
+        detector.observe(_ralph_stdout(f"line {i}"))
+
+    anomaly = detector.observe(_ralph_exited(exit_code=1))[0]
+
+    assert "log_tail" in anomaly.evidence
+    log_tail = anomaly.evidence["log_tail"]
+    assert len(log_tail) == 100
+    assert log_tail[0] == "line 50"
+    assert log_tail[-1] == "line 149"
+
+
+def test_anomaly_log_tail_is_empty_when_no_stdout_seen():
+    detector = AnomalyDetector()
+
+    anomaly = detector.observe(_ralph_exited(exit_code=1))[0]
+
+    assert anomaly.evidence["log_tail"] == []

--- a/tests/test_anomaly.py
+++ b/tests/test_anomaly.py
@@ -6,7 +6,7 @@ are pluggable; the v1 default rule set fires on ralph non-zero exits
 """
 from __future__ import annotations
 
-from smart_ralph.anomaly import AnomalyDetector
+from smart_ralph.anomaly import Anomaly, AnomalyDetector
 
 
 def _ralph_exited(exit_code: int, issue: int = 7) -> dict:
@@ -103,8 +103,6 @@ def test_anomaly_log_tail_is_empty_when_no_stdout_seen():
 def test_register_adds_a_custom_rule_that_fires_alongside_defaults():
     """Custom rules registered via register() must be invoked on every
     observe() call alongside the built-in rule set."""
-    from smart_ralph.anomaly import Anomaly
-
     detector = AnomalyDetector()
 
     def fires_on_run_started(event, _ctx):

--- a/tests/test_anomaly.py
+++ b/tests/test_anomaly.py
@@ -96,3 +96,26 @@ def test_anomaly_log_tail_is_empty_when_no_stdout_seen():
     anomaly = detector.observe(_ralph_exited(exit_code=1))[0]
 
     assert anomaly.evidence["log_tail"] == []
+
+
+# ── register(rule): pluggable rule registration ────────────
+
+def test_register_adds_a_custom_rule_that_fires_alongside_defaults():
+    """Custom rules registered via register() must be invoked on every
+    observe() call alongside the built-in rule set."""
+    from smart_ralph.anomaly import Anomaly
+
+    detector = AnomalyDetector()
+
+    def fires_on_run_started(event, _ctx):
+        if event.get("type") == "run_started":
+            return Anomaly(rule="custom_run_started", issue=event.get("issue"))
+        return None
+
+    detector.register(fires_on_run_started)
+
+    event = {"type": "run_started", "issue": 5, "payload": {}}
+    anomalies = detector.observe(event)
+
+    rules = {a.rule for a in anomalies}
+    assert "custom_run_started" in rules

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,4 +1,5 @@
 import io
+import re
 
 from smart_ralph.dashboard import Dashboard
 
@@ -81,9 +82,12 @@ def test_anomaly_detected_renders_prominent_in_attached_mode():
 
     out = tty.getvalue()
     assert "ralph_nonzero_exit" in out
-    # Rich emits ANSI escapes for red — accept either the SGR code or a
-    # literal "anomaly" marker word so the test isn't tied to one renderer.
-    assert ("\x1b[31m" in out) or ("\x1b[91m" in out) or ("ANOMALY" in out.upper())
+    # Rich emits an ANSI red SGR escape when rendering [bold red] markup.
+    # The exact form may be \x1b[31m, \x1b[91m, or combined like
+    # \x1b[1;31m (bold + red), so look for the color code (31 / 91)
+    # appearing inside any SGR escape.
+    sgr_red = re.search(r"\x1b\[[0-9;]*?(?:31|91)[0-9;]*m", out)
+    assert sgr_red, f"expected red ANSI in dashboard output, got: {out!r}"
 
 
 def test_anomaly_detected_in_plain_mode_writes_one_line():

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -58,3 +58,44 @@ def test_attached_mode_renders_split_pane_without_crashing():
     assert "step 2" in out
     # issue number surfaces in the top pane
     assert "2" in out
+
+
+def test_anomaly_detected_renders_prominent_in_attached_mode():
+    """Anomalies surface in the Progress panel with the rule name and
+    a red marker so the operator can't miss them."""
+    tty = _FakeTTY()
+    dashboard = Dashboard(stream=tty, force_mode="attached")
+    events = [
+        {"type": "run_started", "source": "supervisor", "issue": 7,
+         "payload": {}},
+        {"type": "ralph_exited", "source": "supervisor", "issue": 7,
+         "payload": {"exit_code": 1}},
+        {"type": "anomaly_detected", "source": "supervisor", "issue": 7,
+         "payload": {
+             "rule": "ralph_nonzero_exit",
+             "evidence": {"exit_code": 1, "log_tail": []},
+         }},
+    ]
+
+    dashboard.render(events)
+
+    out = tty.getvalue()
+    assert "ralph_nonzero_exit" in out
+    # Rich emits ANSI escapes for red — accept either the SGR code or a
+    # literal "anomaly" marker word so the test isn't tied to one renderer.
+    assert ("\x1b[31m" in out) or ("\x1b[91m" in out) or ("ANOMALY" in out.upper())
+
+
+def test_anomaly_detected_in_plain_mode_writes_one_line():
+    buf = io.StringIO()
+    dashboard = Dashboard(stream=buf)
+
+    dashboard.emit({
+        "type": "anomaly_detected", "source": "supervisor", "issue": 7,
+        "payload": {"rule": "ralph_nonzero_exit",
+                    "evidence": {"exit_code": 1}},
+    })
+
+    line = buf.getvalue().splitlines()[0]
+    assert "anomaly_detected" in line
+    assert "ralph_nonzero_exit" in line

--- a/tests/test_eventlog.py
+++ b/tests/test_eventlog.py
@@ -97,6 +97,46 @@ def test_oversized_payload_offloaded_to_blob_sidecar(tmp_path):
     assert recovered == big_payload
 
 
+def test_offload_boundary_exactly_at_pipe_buf(tmp_path):
+    """Pin the >4096 vs ≤4096 boundary: a line at exactly 4096 bytes
+    stays inline; one byte more triggers offload."""
+    log = EventLog(tmp_path / "events.jsonl", run_id="run-edge")
+
+    # Sized so the envelope JSON serializes to exactly 4096 bytes inclusive
+    # of the trailing newline. The "pad" field absorbs the difference.
+    base_payload = {"pad": ""}
+    base_envelope = {
+        "schema_version": 1,
+        "ts": "2026-05-05T00:00:00.000Z",
+        "run_id": "run-edge",
+        "type": "anomaly_detected",
+        "source": "supervisor",
+        "issue": 7,
+        "payload": base_payload,
+    }
+    base_line = json.dumps(base_envelope, separators=(",", ":")) + "\n"
+    pad_size = 4096 - len(base_line.encode("utf-8"))
+    assert pad_size > 0
+
+    log.append(
+        event_type="anomaly_detected", source="supervisor",
+        issue=7, payload={"pad": "x" * pad_size},
+    )
+    inline = json.loads((tmp_path / "events.jsonl").read_text().splitlines()[0])
+    assert "blob_ref" not in inline["payload"], (
+        "exactly-4096-byte line should stay inline"
+    )
+
+    # One byte over → offload.
+    (tmp_path / "events.jsonl").unlink()
+    log.append(
+        event_type="anomaly_detected", source="supervisor",
+        issue=7, payload={"pad": "x" * (pad_size + 1)},
+    )
+    over = json.loads((tmp_path / "events.jsonl").read_text().splitlines()[0])
+    assert over["payload"]["oversized"] is True
+
+
 def test_small_payload_not_offloaded(tmp_path):
     log = EventLog(tmp_path / "events.jsonl", run_id="run-small")
 

--- a/tests/test_eventlog.py
+++ b/tests/test_eventlog.py
@@ -67,3 +67,45 @@ def test_prune_runs_keeps_only_last_n_runs(tmp_path):
 
 def test_prune_runs_on_missing_file_is_noop(tmp_path):
     EventLog(tmp_path / "events.jsonl", run_id="run-1").prune_runs(keep=50)
+
+
+# ── Oversized payload offload (issue #7 — anomaly evidence may be huge) ──
+
+def test_oversized_payload_offloaded_to_blob_sidecar(tmp_path):
+    """Match the ralph-events.sh contract on the supervisor side: any line
+    that would exceed the 4KB PIPE_BUF window writes its payload to a
+    sidecar blob and replaces the inline payload with a blob_ref."""
+    log = EventLog(tmp_path / "events.jsonl", run_id="run-big")
+
+    big_payload = {"evidence": {"log_tail": ["x" * 200] * 50}}  # ~10KB inline
+    log.append(
+        event_type="anomaly_detected", source="supervisor",
+        issue=7, payload=big_payload,
+    )
+
+    line = (tmp_path / "events.jsonl").read_text().splitlines()[0]
+    assert len(line.encode("utf-8")) + 1 <= 4096
+
+    evt = json.loads(line)
+    assert evt["payload"]["oversized"] is True
+    blob_rel = evt["payload"]["blob_ref"]
+    assert blob_rel.startswith("blobs/run-big/")
+
+    blob_path = tmp_path / blob_rel
+    assert blob_path.exists()
+    recovered = json.loads(blob_path.read_text())
+    assert recovered == big_payload
+
+
+def test_small_payload_not_offloaded(tmp_path):
+    log = EventLog(tmp_path / "events.jsonl", run_id="run-small")
+
+    log.append(
+        event_type="anomaly_detected", source="supervisor",
+        issue=7, payload={"rule": "x", "evidence": {"exit_code": 1}},
+    )
+
+    evt = json.loads((tmp_path / "events.jsonl").read_text().splitlines()[0])
+    assert "blob_ref" not in evt["payload"]
+    assert "oversized" not in evt["payload"]
+    assert evt["payload"]["evidence"]["exit_code"] == 1

--- a/tests/test_ralph_events.py
+++ b/tests/test_ralph_events.py
@@ -431,8 +431,7 @@ def test_ralph_run_emits_ralph_error_on_iteration_exhaustion(tmp_path):
     )
     claude_shim.chmod(0o755)
     # Copy fake gh alongside
-    import shutil as _shutil
-    _shutil.copy(FAKE_TOOLS / "gh", shim_dir / "gh")
+    shutil.copy(FAKE_TOOLS / "gh", shim_dir / "gh")
     (shim_dir / "gh").chmod(0o755)
 
     events_path = tmp_path / ".smart-ralph" / "events.jsonl"

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -267,6 +267,57 @@ def test_supervisor_and_ralph_share_events_jsonl(tmp_path):
     assert "ralph_iteration_ended" in ralph_types
 
 
+def test_nonzero_ralph_exit_writes_anomaly_detected_event(tmp_path):
+    """Supervisor must feed events through the AnomalyDetector and write
+    any returned anomalies as anomaly_detected events on events.jsonl with
+    matching run_id and source: supervisor."""
+    _init_repo(tmp_path)
+    supervisor = Supervisor(
+        ralph_path=FIXTURES / "exits_nonzero.sh",
+        cwd=tmp_path,
+        required_tools=_all_tools_present(),
+    )
+
+    exit_code, _ = supervisor.run(issue=21)
+    assert exit_code == 1
+
+    events_path = tmp_path / ".smart-ralph" / "events.jsonl"
+    entries = [json.loads(line) for line in events_path.read_text().splitlines()]
+
+    anomaly_events = [e for e in entries if e["type"] == "anomaly_detected"]
+    assert len(anomaly_events) == 1, (
+        f"expected one anomaly_detected, got types={[e['type'] for e in entries]}"
+    )
+    evt = anomaly_events[0]
+    assert evt["source"] == "supervisor"
+    assert evt["issue"] == 21
+    assert evt["payload"]["rule"] == "ralph_nonzero_exit"
+    assert evt["payload"]["evidence"]["exit_code"] == 1
+    # log_tail came from the stdout the supervisor saw before exit.
+    log_tail = evt["payload"]["evidence"]["log_tail"]
+    assert "ralph: starting" in log_tail
+    assert "ralph: hitting an error" in log_tail
+
+    # All events share the supervisor's run_id.
+    run_ids = {e["run_id"] for e in entries}
+    assert len(run_ids) == 1
+
+
+def test_zero_exit_does_not_write_anomaly_detected(tmp_path):
+    _init_repo(tmp_path)
+    supervisor = Supervisor(
+        ralph_path=FIXTURES / "echo_stdout.sh",
+        cwd=tmp_path,
+        required_tools=_all_tools_present(),
+    )
+
+    supervisor.run(issue=22)
+
+    events_path = tmp_path / ".smart-ralph" / "events.jsonl"
+    entries = [json.loads(line) for line in events_path.read_text().splitlines()]
+    assert not [e for e in entries if e["type"] == "anomaly_detected"]
+
+
 def test_kill_exception_on_sigint_is_logged_as_repair_failed(tmp_path):
     """If RalphClient.kill raises during SIGINT, the failure must be audit-logged
     (not silently swallowed) and the run must still exit cleanly."""

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -303,6 +303,56 @@ def test_nonzero_ralph_exit_writes_anomaly_detected_event(tmp_path):
     assert len(run_ids) == 1
 
 
+def test_stdout_stream_anomalies_are_recorded_not_just_at_exit(tmp_path, monkeypatch):
+    """Anomalies returned while the supervisor is draining ralph's stdout
+    must be written to events.jsonl too — not silently dropped because the
+    loop only records on ralph_exited."""
+    from smart_ralph import anomaly as anomaly_module
+
+    def stdout_marker_rule(event, _ctx):
+        if event.get("type") != "ralph_stdout":
+            return None
+        if "BANG" not in event.get("payload", {}).get("line", ""):
+            return None
+        return anomaly_module.Anomaly(
+            rule="stdout_marker_seen",
+            issue=event.get("issue"),
+            evidence={"line": event["payload"]["line"]},
+        )
+
+    # Patch AnomalyDetector to register our rule by default for this test.
+    original_init = anomaly_module.AnomalyDetector.__init__
+
+    def patched_init(self):
+        original_init(self)
+        self.register(stdout_marker_rule)
+
+    monkeypatch.setattr(anomaly_module.AnomalyDetector, "__init__", patched_init)
+
+    # fixture stub that prints a stdout line containing "BANG", then exits 0
+    bang = tmp_path / "bang.sh"
+    bang.write_text(
+        '#!/usr/bin/env bash\n'
+        'echo "BANG goes the issue"\n'
+        'echo "ok"\n'
+    )
+    bang.chmod(0o755)
+
+    _init_repo(tmp_path)
+    Supervisor(
+        ralph_path=bang,
+        cwd=tmp_path,
+        required_tools=_all_tools_present(),
+    ).run(issue=99)
+
+    events_path = tmp_path / ".smart-ralph" / "events.jsonl"
+    entries = [json.loads(line) for line in events_path.read_text().splitlines()]
+    anomalies = [e for e in entries if e["type"] == "anomaly_detected"]
+    assert any(a["payload"]["rule"] == "stdout_marker_seen" for a in anomalies), (
+        f"expected stdout_marker_seen anomaly, got {[a['payload']['rule'] for a in anomalies]}"
+    )
+
+
 def test_zero_exit_does_not_write_anomaly_detected(tmp_path):
     _init_repo(tmp_path)
     supervisor = Supervisor(

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -31,6 +31,38 @@ def _all_tools_present() -> list[str]:
     return ["git"]
 
 
+def _stdout_marker_rule(event, _ctx):
+    """Custom rule used by anomaly-detection tests: fires when a stdout
+    line contains the literal "BANG"."""
+    if event.get("type") != "ralph_stdout":
+        return None
+    if "BANG" not in event.get("payload", {}).get("line", ""):
+        return None
+    return Anomaly(
+        rule="stdout_marker_seen",
+        issue=event.get("issue"),
+        evidence={"line": event["payload"]["line"]},
+    )
+
+
+def _build_detector_with_marker_rule() -> AnomalyDetector:
+    detector = AnomalyDetector()
+    detector.register(_stdout_marker_rule)
+    return detector
+
+
+def _write_bang_fixture(path: Path) -> Path:
+    """Fake ralph: prints a BANG stdout line, then exits 0."""
+    bang = path / "bang.sh"
+    bang.write_text(
+        '#!/usr/bin/env bash\n'
+        'echo "BANG goes the issue"\n'
+        'echo "ok"\n'
+    )
+    bang.chmod(0o755)
+    return bang
+
+
 def test_lockfile_is_created_during_run_and_removed_on_exit(tmp_path):
     _init_repo(tmp_path)
     supervisor = Supervisor(
@@ -304,36 +336,6 @@ def test_nonzero_ralph_exit_writes_anomaly_detected_event(tmp_path):
     assert len(run_ids) == 1
 
 
-def _stdout_marker_rule(event, _ctx):
-    if event.get("type") != "ralph_stdout":
-        return None
-    if "BANG" not in event.get("payload", {}).get("line", ""):
-        return None
-    return Anomaly(
-        rule="stdout_marker_seen",
-        issue=event.get("issue"),
-        evidence={"line": event["payload"]["line"]},
-    )
-
-
-def _build_detector_with_marker_rule() -> AnomalyDetector:
-    detector = AnomalyDetector()
-    detector.register(_stdout_marker_rule)
-    return detector
-
-
-def _write_bang_fixture(path: Path) -> Path:
-    """Fake ralph: prints a BANG stdout line, then exits 0."""
-    bang = path / "bang.sh"
-    bang.write_text(
-        '#!/usr/bin/env bash\n'
-        'echo "BANG goes the issue"\n'
-        'echo "ok"\n'
-    )
-    bang.chmod(0o755)
-    return bang
-
-
 def test_stdout_stream_anomalies_are_recorded_not_just_at_exit(tmp_path):
     """Anomalies returned while the supervisor is draining ralph's stdout
     must be written to events.jsonl too — not silently dropped because the
@@ -383,13 +385,14 @@ def test_each_run_constructs_a_fresh_detector(tmp_path):
     assert constructed[0] is not constructed[1]
 
 
-def test_default_detector_factory_isolates_runs(tmp_path):
-    """No factory injected — default behavior must still produce a fresh
-    detector per run (regression on the asymmetry the factory refactor
-    eliminates)."""
+def test_default_detector_factory_isolates_log_tail_across_runs(tmp_path):
+    """No factory injected — default behavior must give each run a fresh
+    detector, observable via log_tail isolation. The fixture prints
+    exactly 3 stdout lines per invocation; two back-to-back runs that
+    shared state would yield a 6-line log_tail in the second anomaly."""
     _init_repo(tmp_path)
     supervisor = Supervisor(
-        ralph_path=FIXTURES / "echo_stdout.sh",
+        ralph_path=FIXTURES / "exits_nonzero.sh",
         cwd=tmp_path,
         required_tools=_all_tools_present(),
     )
@@ -398,9 +401,25 @@ def test_default_detector_factory_isolates_runs(tmp_path):
 
     events_path = tmp_path / ".smart-ralph" / "events.jsonl"
     entries = [json.loads(line) for line in events_path.read_text().splitlines()]
-    # Both runs landed; their run_ids differ.
-    run_ids = {e["run_id"] for e in entries}
-    assert len(run_ids) == 2
+
+    # Group anomaly_detected events by run_id to inspect each run in isolation.
+    anomalies_by_run: dict[str, list[dict]] = {}
+    for e in entries:
+        if e["type"] == "anomaly_detected":
+            anomalies_by_run.setdefault(e["run_id"], []).append(e)
+
+    assert len(anomalies_by_run) == 2, (
+        f"expected 2 distinct run_ids in anomaly events, got {list(anomalies_by_run)}"
+    )
+    for run_id, anomalies in anomalies_by_run.items():
+        assert len(anomalies) == 1
+        log_tail = anomalies[0]["payload"]["evidence"]["log_tail"]
+        # exits_nonzero.sh emits 3 stdout lines per run. If state had
+        # leaked from a previous run, log_tail would carry up to 6 lines.
+        assert len(log_tail) <= 3, (
+            f"run {run_id} log_tail has {len(log_tail)} lines — state leaked"
+            f" from a prior run (fixture prints only 3 per invocation)"
+        )
 
 
 def test_zero_exit_does_not_write_anomaly_detected(tmp_path):

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -304,40 +304,47 @@ def test_nonzero_ralph_exit_writes_anomaly_detected_event(tmp_path):
     assert len(run_ids) == 1
 
 
-def test_stdout_stream_anomalies_are_recorded_not_just_at_exit(tmp_path):
-    """Anomalies returned while the supervisor is draining ralph's stdout
-    must be written to events.jsonl too — not silently dropped because the
-    loop only records on ralph_exited."""
+def _stdout_marker_rule(event, _ctx):
+    if event.get("type") != "ralph_stdout":
+        return None
+    if "BANG" not in event.get("payload", {}).get("line", ""):
+        return None
+    return Anomaly(
+        rule="stdout_marker_seen",
+        issue=event.get("issue"),
+        evidence={"line": event["payload"]["line"]},
+    )
+
+
+def _build_detector_with_marker_rule() -> AnomalyDetector:
     detector = AnomalyDetector()
+    detector.register(_stdout_marker_rule)
+    return detector
 
-    def stdout_marker_rule(event, _ctx):
-        if event.get("type") != "ralph_stdout":
-            return None
-        if "BANG" not in event.get("payload", {}).get("line", ""):
-            return None
-        return Anomaly(
-            rule="stdout_marker_seen",
-            issue=event.get("issue"),
-            evidence={"line": event["payload"]["line"]},
-        )
 
-    detector.register(stdout_marker_rule)
-
-    # fixture stub that prints a stdout line containing "BANG", then exits 0
-    bang = tmp_path / "bang.sh"
+def _write_bang_fixture(path: Path) -> Path:
+    """Fake ralph: prints a BANG stdout line, then exits 0."""
+    bang = path / "bang.sh"
     bang.write_text(
         '#!/usr/bin/env bash\n'
         'echo "BANG goes the issue"\n'
         'echo "ok"\n'
     )
     bang.chmod(0o755)
+    return bang
 
+
+def test_stdout_stream_anomalies_are_recorded_not_just_at_exit(tmp_path):
+    """Anomalies returned while the supervisor is draining ralph's stdout
+    must be written to events.jsonl too — not silently dropped because the
+    loop only records on ralph_exited."""
+    bang = _write_bang_fixture(tmp_path)
     _init_repo(tmp_path)
     Supervisor(
         ralph_path=bang,
         cwd=tmp_path,
         required_tools=_all_tools_present(),
-        detector=detector,
+        detector_factory=_build_detector_with_marker_rule,
     ).run(issue=99)
 
     events_path = tmp_path / ".smart-ralph" / "events.jsonl"
@@ -346,6 +353,54 @@ def test_stdout_stream_anomalies_are_recorded_not_just_at_exit(tmp_path):
     assert any(a["payload"]["rule"] == "stdout_marker_seen" for a in anomalies), (
         f"expected stdout_marker_seen anomaly, got {[a['payload']['rule'] for a in anomalies]}"
     )
+
+
+def test_each_run_constructs_a_fresh_detector(tmp_path):
+    """Repeated run() calls on the same Supervisor must construct a fresh
+    detector each time. State (e.g., the bounded log_tail or any per-rule
+    counters) must not leak between runs."""
+    bang = _write_bang_fixture(tmp_path)
+    _init_repo(tmp_path)
+
+    constructed: list[AnomalyDetector] = []
+
+    def factory() -> AnomalyDetector:
+        d = _build_detector_with_marker_rule()
+        constructed.append(d)
+        return d
+
+    supervisor = Supervisor(
+        ralph_path=bang,
+        cwd=tmp_path,
+        required_tools=_all_tools_present(),
+        detector_factory=factory,
+    )
+
+    supervisor.run(issue=101)
+    supervisor.run(issue=102)
+
+    assert len(constructed) == 2
+    assert constructed[0] is not constructed[1]
+
+
+def test_default_detector_factory_isolates_runs(tmp_path):
+    """No factory injected — default behavior must still produce a fresh
+    detector per run (regression on the asymmetry the factory refactor
+    eliminates)."""
+    _init_repo(tmp_path)
+    supervisor = Supervisor(
+        ralph_path=FIXTURES / "echo_stdout.sh",
+        cwd=tmp_path,
+        required_tools=_all_tools_present(),
+    )
+    supervisor.run(issue=201)
+    supervisor.run(issue=202)
+
+    events_path = tmp_path / ".smart-ralph" / "events.jsonl"
+    entries = [json.loads(line) for line in events_path.read_text().splitlines()]
+    # Both runs landed; their run_ids differ.
+    run_ids = {e["run_id"] for e in entries}
+    assert len(run_ids) == 2
 
 
 def test_zero_exit_does_not_write_anomaly_detected(tmp_path):

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from smart_ralph.anomaly import Anomaly, AnomalyDetector
 from smart_ralph.supervisor import ConcurrentRunError, HealthCheckError, Supervisor
 
 FIXTURES = Path(__file__).parent / "fixtures" / "fake_ralph"
@@ -303,31 +304,24 @@ def test_nonzero_ralph_exit_writes_anomaly_detected_event(tmp_path):
     assert len(run_ids) == 1
 
 
-def test_stdout_stream_anomalies_are_recorded_not_just_at_exit(tmp_path, monkeypatch):
+def test_stdout_stream_anomalies_are_recorded_not_just_at_exit(tmp_path):
     """Anomalies returned while the supervisor is draining ralph's stdout
     must be written to events.jsonl too — not silently dropped because the
     loop only records on ralph_exited."""
-    from smart_ralph import anomaly as anomaly_module
+    detector = AnomalyDetector()
 
     def stdout_marker_rule(event, _ctx):
         if event.get("type") != "ralph_stdout":
             return None
         if "BANG" not in event.get("payload", {}).get("line", ""):
             return None
-        return anomaly_module.Anomaly(
+        return Anomaly(
             rule="stdout_marker_seen",
             issue=event.get("issue"),
             evidence={"line": event["payload"]["line"]},
         )
 
-    # Patch AnomalyDetector to register our rule by default for this test.
-    original_init = anomaly_module.AnomalyDetector.__init__
-
-    def patched_init(self):
-        original_init(self)
-        self.register(stdout_marker_rule)
-
-    monkeypatch.setattr(anomaly_module.AnomalyDetector, "__init__", patched_init)
+    detector.register(stdout_marker_rule)
 
     # fixture stub that prints a stdout line containing "BANG", then exits 0
     bang = tmp_path / "bang.sh"
@@ -343,6 +337,7 @@ def test_stdout_stream_anomalies_are_recorded_not_just_at_exit(tmp_path, monkeyp
         ralph_path=bang,
         cwd=tmp_path,
         required_tools=_all_tools_present(),
+        detector=detector,
     ).run(issue=99)
 
     events_path = tmp_path / ".smart-ralph" / "events.jsonl"


### PR DESCRIPTION
## Summary

- New `AnomalyDetector` (`src/smart_ralph/anomaly.py`) — stateful, pluggable. Public surface: `observe(event) -> [Anomaly]` and `register(rule)`. Default rule set has one entry: `ralph_nonzero_exit`, which fires when ralph exits with any code other than `0`, `42` (Claude rate limit, handled separately), or `130` (SIGINT, user-initiated). Rules receive a `Context` snapshot so they can read accumulated state (today: a 100-line stdout tail) without coupling to the detector internals.
- Supervisor now feeds every event it sees (stdout via `process.events()`, plus the `ralph_exited` envelope it builds) through the detector. Any returned `Anomaly` is written to `events.jsonl` as `source: "supervisor"` `type: "anomaly_detected"` carrying `{rule, evidence}`. Observe-only — no routing, no repair.
- `EventLog.append` auto-offloads any line that would exceed the 4KB PIPE_BUF window to a sidecar blob under `.smart-ralph/blobs/<run_id>/`, replacing the inline payload with `{oversized: true, blob_ref: ...}`. Mirrors `lib/ralph-events.sh` on the bash side, so both writers handle oversized payloads identically.
- Dashboard surfaces the latest anomaly in the Progress panel with a red `ANOMALY:` marker; plain mode emits the standard `[anomaly_detected] rule=...` line.

Closes #7.

## Test plan

49/49 tests pass (`.venv/bin/python -m pytest`). New coverage:

- [x] `AnomalyDetector.observe(ralph_exited, exit_code=1)` returns one Anomaly with rule `ralph_nonzero_exit`
- [x] Exit codes 0, 42, 130 produce no anomaly
- [x] Anomaly evidence carries `exit_code`
- [x] Detector accumulates ralph_stdout into a 100-line bounded buffer; trimming behavior verified at 150 lines fed
- [x] Anomaly evidence carries the snapshot `log_tail` (empty when no stdout was seen)
- [x] Supervisor end-to-end: fake ralph stub exits 1 → exactly one `anomaly_detected` event with matching `run_id`, source `supervisor`, correct rule + evidence
- [x] Zero-exit ralph produces no anomaly_detected event
- [x] EventLog offloads oversized payloads to `blobs/<run_id>/...` and replaces with `blob_ref`; line stays ≤4KB
- [x] EventLog leaves small payloads inline
- [x] Dashboard attached mode: anomaly_detected event surfaces rule name with red ANSI styling
- [x] Dashboard plain mode: anomaly_detected event writes one line containing the rule

## Manual verification

- [ ] Run `./smart-ralph <issue>` against a deliberately-failing PRD; tail `.smart-ralph/events.jsonl` and confirm an `anomaly_detected` event lands after `ralph_exited`
- [ ] Watch the dashboard during the run; confirm the red ANOMALY marker appears in the Progress pane