### PR TITLE
Add diagnose-ralph skill + DiagnosticRouter + ClaudeProvider (#8)

### DIFF
--- a/.claude/skills/diagnose-ralph/SKILL.md
+++ b/.claude/skills/diagnose-ralph/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: diagnose-ralph
+version: 1
+description: Programmatic-use only. Invoked headlessly by the smart-ralph supervisor when an anomaly fires. Reads the anomaly + supervisor context, classifies the failure, and emits a single <diagnosis>{...}</diagnosis> JSON block.
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash(jq:*)
+  - Bash(git log:*)
+  - Bash(git status:*)
+  - Bash(git diff:*)
+  - Bash(cat .ralph/*)
+  - Edit(.ralph/state.json)
+---
+
+# diagnose-ralph
+
+You are the diagnose-ralph skill. The smart-ralph supervisor has detected
+an anomaly during a ralph orchestration run and is invoking you headlessly
+via `claude -p`. **Do not produce conversational output.** Your single job
+is to classify the failure and emit one valid `<diagnosis>` block per the
+output contract below. The supervisor parses your output deterministically.
+
+## Input contract
+
+The supervisor sends a single JSON envelope on stdin (in the prompt):
+
+```json
+{
+  "anomaly": {
+    "rule": "<rule name, e.g. ralph_nonzero_exit>",
+    "issue": <int or null>,
+    "evidence": { "exit_code": ..., "log_tail": [...], ... }
+  },
+  "context": {
+    "issue": <int>,
+    "state_snapshot": { ... },
+    "log_tail": [ ... ],
+    "iterations": <int>
+  }
+}
+```
+
+You may use your `allowed-tools` to read further state — `gh issue view
+<n>`, `cat .ralph/state.json`, `git log/status/diff`, file reads, etc. —
+but do not edit anything other than `.ralph/state.json`.
+
+## Output contract
+
+Emit exactly one XML block, on its own. No prose before or after.
+
+```
+<diagnosis>{
+  "scope": "orchestrator" | "product" | "unknown",
+  "fix_type": "state_patch" | "restart" | "worktree_reset" | "rebase" | "escalate" | null,
+  "action": { ... fix-type-specific payload ... } | null,
+  "confidence": "low" | "medium" | "high",
+  "summary": "<one-line human-readable explanation>",
+  "evidence": { ... structured citations from your investigation ... }
+}</diagnosis>
+```
+
+### Field semantics
+
+- **scope** — Where the bug lives.
+  - `orchestrator`: ralph itself is stuck (stale state, dead loop, missed
+    transition). The supervisor will apply your fix directly.
+  - `product`: the thing ralph is building is broken. The supervisor will
+    hand off to the auto-triage skill to file/amend a GitHub issue.
+  - `unknown`: you cannot determine the scope. The supervisor escalates
+    to `needs_human`.
+- **fix_type** — What action the supervisor should take. Required when
+  `scope == "orchestrator"`. May be `null` when `scope` is `product` or
+  `unknown` (the supervisor routes elsewhere). Set to `"escalate"` if
+  the orchestrator is unrepairable from your seat.
+- **action** — Fix-type-specific payload. Examples:
+  - `state_patch`: `{ "path": ".ralph/state.json", "key": "...", "value": ... }`
+  - `restart`: `{}` (supervisor will respawn ralph fresh)
+  - `worktree_reset`: `{ "branch": "..." }`
+  - `rebase`: `{ "onto": "origin/main" }`
+- **confidence** — Calibrate honestly. The supervisor treats `low` as a
+  signal to mark `needs_human` rather than auto-applying.
+- **summary** — One sentence. Used in event logs and dashboards.
+- **evidence** — Structured citations: file paths read, git SHAs
+  observed, log lines that drove the conclusion. Aids audit.
+
+## Hard rules
+
+1. Output exactly one `<diagnosis>` block. The supervisor parses
+   non-greedily; multiple blocks lead to undefined behavior.
+2. The block must be valid JSON. No trailing commas, no comments, no
+   unquoted keys.
+3. If you cannot reach a confident classification, return
+   `scope: "unknown"` with `confidence: "low"`. The supervisor will
+   handle escalation. Do not invent fixes you are not sure about.
+4. Never edit anything outside `.ralph/state.json`. The supervisor's
+   permission allowlist enforces this; do not work around it.

--- a/src/smart_ralph/provider.py
+++ b/src/smart_ralph/provider.py
@@ -1,0 +1,64 @@
+"""Provider adapters — headless invokers for model runners.
+
+v1 ships ClaudeProvider, which spawns `claude -p --permission-mode dontAsk`.
+The Protocol is defined alongside so v2 adapters (Codex, Gemini, local
+models) can plug in without touching the router.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+# Default subprocess timeout for a single headless skill invocation.
+# Large enough that diagnose-ralph can read several files via Read/Grep,
+# small enough that a hung claude doesn't block the supervisor forever.
+_DEFAULT_TIMEOUT_SECONDS = 300
+
+
+class ClaudeProvider:
+    """v1 Provider implementation: spawns `claude -p` with the dontAsk
+    permission mode and a per-skill allowlist."""
+
+    def __init__(
+        self,
+        claude_path: Path | None = None,
+        *,
+        timeout_seconds: int = _DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        if claude_path is None:
+            override = os.environ.get("SMART_RALPH_CLAUDE_PATH")
+            if override:
+                claude_path = Path(override)
+            else:
+                found = shutil.which("claude")
+                if found is None:
+                    raise RuntimeError(
+                        "claude not found on PATH and SMART_RALPH_CLAUDE_PATH "
+                        "is not set"
+                    )
+                claude_path = Path(found)
+        self._claude_path = Path(claude_path)
+        self._timeout_seconds = timeout_seconds
+
+    def run_headless(self, prompt: str, *, allowed_tools: list[str]) -> str:
+        argv = [
+            str(self._claude_path),
+            "-p",
+            "--permission-mode", "dontAsk",
+        ]
+        if allowed_tools:
+            # claude --allowed-tools accepts a comma-separated list; pass
+            # exactly the allowlist the caller asked for.
+            argv += ["--allowed-tools", ",".join(allowed_tools)]
+        argv.append(prompt)
+
+        result = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=self._timeout_seconds,
+        )
+        return result.stdout

--- a/src/smart_ralph/provider.py
+++ b/src/smart_ralph/provider.py
@@ -19,13 +19,20 @@ _DEFAULT_TIMEOUT_SECONDS = 300
 
 class ClaudeProvider:
     """v1 Provider implementation: spawns `claude -p` with the dontAsk
-    permission mode and a per-skill allowlist."""
+    permission mode and a per-skill allowlist.
+
+    Subprocess-level failures (timeout, missing binary, OSError from a
+    transient kernel issue) are absorbed and surfaced as an empty stdout
+    string. The router's parser treats empty/malformed output as a
+    retry-then-escalate path, so a hung or missing claude can never take
+    down the supervised orchestration."""
 
     def __init__(
         self,
         claude_path: Path | None = None,
         *,
         timeout_seconds: int = _DEFAULT_TIMEOUT_SECONDS,
+        cwd: Path | None = None,
     ) -> None:
         if claude_path is None:
             override = os.environ.get("SMART_RALPH_CLAUDE_PATH")
@@ -41,6 +48,9 @@ class ClaudeProvider:
                 claude_path = Path(found)
         self._claude_path = Path(claude_path)
         self._timeout_seconds = timeout_seconds
+        # Setting cwd lets the child claude process discover the project's
+        # `.claude/skills/` tree. Default None inherits the parent's cwd.
+        self._cwd = Path(cwd) if cwd is not None else None
 
     def run_headless(self, prompt: str, *, allowed_tools: list[str]) -> str:
         argv = [
@@ -54,11 +64,17 @@ class ClaudeProvider:
             argv += ["--allowed-tools", ",".join(allowed_tools)]
         argv.append(prompt)
 
-        result = subprocess.run(
-            argv,
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=self._timeout_seconds,
-        )
+        try:
+            result = subprocess.run(
+                argv,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=self._timeout_seconds,
+                cwd=str(self._cwd) if self._cwd is not None else None,
+            )
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+            # Hung or missing binary, kernel hiccup — return "" and let
+            # the router's malformed-output retry/escalate path handle it.
+            return ""
         return result.stdout

--- a/src/smart_ralph/provider.py
+++ b/src/smart_ralph/provider.py
@@ -71,7 +71,7 @@ class ClaudeProvider:
                 text=True,
                 check=False,
                 timeout=self._timeout_seconds,
-                cwd=str(self._cwd) if self._cwd is not None else None,
+                cwd=self._cwd,
             )
         except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
             # Hung or missing binary, kernel hiccup — return "" and let

--- a/src/smart_ralph/router.py
+++ b/src/smart_ralph/router.py
@@ -1,0 +1,200 @@
+"""Diagnostic routing — invokes the diagnose-ralph skill on an anomaly,
+parses the <diagnosis>{...}</diagnosis> XML block returned by Claude, and
+yields a Decision the supervisor can act on.
+
+This module is observe-only in the v1 slice that introduces it: it parses
+and logs the proposal but never applies any fix. The repair pathway lands
+in a follow-up slice.
+"""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Protocol
+
+from smart_ralph.anomaly import Anomaly
+from smart_ralph.eventlog import EventLog
+
+
+class Provider(Protocol):
+    """Headless model-runner adapter. v1 ships ClaudeProvider; the Protocol
+    exists so v2 can plug in Codex / Gemini / local models without touching
+    the router."""
+
+    def run_headless(self, prompt: str, *, allowed_tools: list[str]) -> str: ...
+
+
+@dataclass(frozen=True)
+class Decision:
+    """Parsed diagnosis output. needs_human is set by the router when it
+    has exhausted retries against malformed provider output, so the
+    supervisor doesn't have to re-derive it."""
+    scope: str
+    fix_type: str | None
+    action: dict[str, Any] | None
+    confidence: str
+    summary: str
+    evidence: dict[str, Any] = field(default_factory=dict)
+    needs_human: bool = False
+
+
+_DIAGNOSIS_BLOCK = re.compile(r"<diagnosis>(.*?)</diagnosis>", re.DOTALL)
+
+# Allowed tools the supervisor exposes to the diagnose-ralph skill. Mirrors
+# the SKILL.md frontmatter; defined here as the source of truth for the
+# headless provider invocation.
+_ALLOWED_TOOLS = [
+    "Read", "Grep", "Glob",
+    "Bash(jq:*)", "Bash(git log:*)", "Bash(git status:*)",
+    "Bash(git diff:*)", "Bash(cat .ralph/*)",
+    "Edit(.ralph/state.json)",
+]
+
+
+_SKILL_SOURCE = "skill:diagnose-ralph"
+EXPECTED_SKILL_VERSION = 1
+
+
+class SkillVersionError(RuntimeError):
+    """Raised when the on-disk skill's frontmatter version does not match
+    the version this code was written against. Forces a deliberate
+    contract bump rather than silent drift."""
+
+
+_FRONTMATTER = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+
+
+def _read_skill_version(skill_path: Path) -> int:
+    """Parse the `version:` field out of SKILL.md frontmatter without
+    pulling in a YAML dependency. Frontmatter is YAML by convention but
+    we only need one integer field."""
+    text = skill_path.read_text()
+    match = _FRONTMATTER.match(text)
+    if match is None:
+        raise SkillVersionError(
+            f"{skill_path}: missing YAML frontmatter (expected `version:` key)"
+        )
+    for line in match.group(1).splitlines():
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        if key.strip() == "version":
+            try:
+                return int(value.strip())
+            except ValueError as e:
+                raise SkillVersionError(
+                    f"{skill_path}: `version:` must be an integer, "
+                    f"got {value.strip()!r}"
+                ) from e
+    raise SkillVersionError(
+        f"{skill_path}: frontmatter is missing the `version:` key"
+    )
+
+
+class DiagnosticRouter:
+    def __init__(
+        self,
+        provider: Provider,
+        *,
+        event_log: EventLog | None = None,
+        skill_path: Path | None = None,
+    ) -> None:
+        if skill_path is not None:
+            actual = _read_skill_version(skill_path)
+            if actual != EXPECTED_SKILL_VERSION:
+                raise SkillVersionError(
+                    f"diagnose-ralph SKILL.md version {actual} does not "
+                    f"match supervisor expected version "
+                    f"{EXPECTED_SKILL_VERSION} ({skill_path})"
+                )
+        self._provider = provider
+        self._event_log = event_log
+
+    def route(self, anomaly: Anomaly, *, context: dict[str, Any]) -> Decision:
+        self._emit("diagnosis_started", anomaly.issue, {"rule": anomaly.rule})
+        prompt = self._build_prompt(anomaly, context)
+        output = self._provider.run_headless(prompt, allowed_tools=list(_ALLOWED_TOOLS))
+
+        decision = self._try_parse(output)
+        if decision is None:
+            corrective = self._build_corrective_prompt(prompt, output)
+            output = self._provider.run_headless(
+                corrective, allowed_tools=list(_ALLOWED_TOOLS),
+            )
+            decision = self._try_parse(output)
+        if decision is None:
+            self._emit("diagnosis_failed", anomaly.issue, {
+                "reason": "malformed_output",
+                "attempts": 2,
+            })
+            return Decision(
+                scope="unknown",
+                fix_type=None,
+                action=None,
+                confidence="low",
+                summary="diagnose-ralph emitted malformed output twice",
+                evidence={"rule": anomaly.rule},
+                needs_human=True,
+            )
+
+        self._emit("diagnosis_completed", anomaly.issue, {
+            "scope": decision.scope,
+            "fix_type": decision.fix_type,
+            "confidence": decision.confidence,
+            "summary": decision.summary,
+        })
+        return decision
+
+    def _emit(self, event_type: str, issue: int | None, payload: dict[str, Any]) -> None:
+        if self._event_log is None:
+            return
+        self._event_log.append(
+            event_type=event_type, source=_SKILL_SOURCE,
+            issue=issue, payload=payload,
+        )
+
+    def _build_prompt(self, anomaly: Anomaly, context: dict[str, Any]) -> str:
+        envelope = {
+            "anomaly": {
+                "rule": anomaly.rule,
+                "issue": anomaly.issue,
+                "evidence": anomaly.evidence,
+            },
+            "context": context,
+        }
+        return (
+            "You are the diagnose-ralph skill. Read the anomaly and "
+            "context below and emit a single <diagnosis>{...}</diagnosis> "
+            "JSON block per the SKILL.md output contract.\n\n"
+            f"{json.dumps(envelope, separators=(',', ':'))}"
+        )
+
+    def _try_parse(self, output: str) -> Decision | None:
+        match = _DIAGNOSIS_BLOCK.search(output)
+        if not match:
+            return None
+        try:
+            body = json.loads(match.group(1))
+            return Decision(
+                scope=body["scope"],
+                fix_type=body.get("fix_type"),
+                action=body.get("action"),
+                confidence=body["confidence"],
+                summary=body["summary"],
+                evidence=body.get("evidence", {}),
+            )
+        except (json.JSONDecodeError, KeyError):
+            return None
+
+    def _build_corrective_prompt(self, original: str, bad_output: str) -> str:
+        return (
+            "Your previous response did not contain a valid "
+            "<diagnosis>{...}</diagnosis> JSON block. Re-emit the diagnosis "
+            "now, exactly per the SKILL.md output contract.\n\n"
+            "Original prompt:\n"
+            f"{original}\n\n"
+            "Your previous (invalid) output:\n"
+            f"{bad_output}"
+        )

--- a/src/smart_ralph/router.py
+++ b/src/smart_ralph/router.py
@@ -69,16 +69,16 @@ _DEFAULT_SKILL_PATH = (
 # Sentinels for skill_path policy. Distinct typed classes (rather than
 # bare object() instances) keep the constructor's type hint exhaustive
 # under strict type checkers.
-class _UseDefault:
+class UseDefault:
     """Sentinel: use the canonical project SKILL.md."""
 
 
-class _SkipSkillCheck:
-    """Sentinel: skip the version check entirely (test harnesses)."""
+class SkipSkillCheck:
+    """Sentinel: caller opts out of the version check."""
 
 
-_USE_DEFAULT_SKILL_PATH = _UseDefault()
-SKIP_SKILL_CHECK = _SkipSkillCheck()
+_USE_DEFAULT_SKILL_PATH = UseDefault()
+SKIP_SKILL_CHECK = SkipSkillCheck()
 
 
 class SkillVersionError(RuntimeError):
@@ -123,18 +123,28 @@ class DiagnosticRouter:
         provider: Provider,
         *,
         event_log: EventLog | None = None,
-        skill_path: Path | _UseDefault | _SkipSkillCheck = _USE_DEFAULT_SKILL_PATH,
+        skill_path: Path | UseDefault | SkipSkillCheck = _USE_DEFAULT_SKILL_PATH,
     ) -> None:
         # Resolve skill_path policy:
-        #   _UseDefault       → canonical project SKILL.md (version-check ON)
-        #   _SkipSkillCheck   → caller explicitly opts out (test harness)
+        #   UseDefault       → canonical project SKILL.md (version-check ON)
+        #   SkipSkillCheck   → caller explicitly opts out
         #   Path              → caller supplies a specific file
         # Forces the version check to be the default; callers must opt
         # out via SKIP_SKILL_CHECK rather than by silently omitting it.
+        # If the canonical file cannot be located when the default was
+        # requested, raise loudly — the version check must never be
+        # silently bypassed (#28 tracks fixing path discovery for
+        # bundled-distribution layouts).
         resolved: Path | None
-        if isinstance(skill_path, _UseDefault):
-            resolved = _DEFAULT_SKILL_PATH if _DEFAULT_SKILL_PATH.exists() else None
-        elif isinstance(skill_path, _SkipSkillCheck):
+        if isinstance(skill_path, UseDefault):
+            if not _DEFAULT_SKILL_PATH.exists():
+                raise SkillVersionError(
+                    f"canonical SKILL.md not found at {_DEFAULT_SKILL_PATH}; "
+                    f"pass skill_path=<Path> explicitly, or "
+                    f"skill_path=SKIP_SKILL_CHECK to opt out of the check"
+                )
+            resolved = _DEFAULT_SKILL_PATH
+        elif isinstance(skill_path, SkipSkillCheck):
             resolved = None
         else:
             resolved = skill_path

--- a/src/smart_ralph/router.py
+++ b/src/smart_ralph/router.py
@@ -56,6 +56,24 @@ _ALLOWED_TOOLS = [
 _SKILL_SOURCE = "skill:diagnose-ralph"
 EXPECTED_SKILL_VERSION = 1
 
+# Canonical on-disk location of the diagnose-ralph SKILL.md, relative to
+# the repo root. Used as the default for DiagnosticRouter.skill_path so
+# callers cannot accidentally bypass the version check by forgetting to
+# pass it.
+_DEFAULT_SKILL_PATH = (
+    Path(__file__).resolve().parent.parent.parent
+    / ".claude" / "skills" / "diagnose-ralph" / "SKILL.md"
+)
+
+
+# Sentinel for "skip the skill version check entirely" — distinct from
+# default (canonical SKILL.md) and from a user-supplied custom path.
+class _SkipSkillCheck:
+    pass
+
+
+SKIP_SKILL_CHECK = _SkipSkillCheck()
+
 
 class SkillVersionError(RuntimeError):
     """Raised when the on-disk skill's frontmatter version does not match
@@ -66,7 +84,7 @@ class SkillVersionError(RuntimeError):
 _FRONTMATTER = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 
 
-def _read_skill_version(skill_path: Path) -> int:
+def read_skill_version(skill_path: Path) -> int:
     """Parse the `version:` field out of SKILL.md frontmatter without
     pulling in a YAML dependency. Frontmatter is YAML by convention but
     we only need one integer field."""
@@ -93,21 +111,38 @@ def _read_skill_version(skill_path: Path) -> int:
     )
 
 
+_DEFAULT_PATH_SENTINEL = object()
+
+
 class DiagnosticRouter:
     def __init__(
         self,
         provider: Provider,
         *,
         event_log: EventLog | None = None,
-        skill_path: Path | None = None,
+        skill_path: "Path | _SkipSkillCheck | object" = _DEFAULT_PATH_SENTINEL,
     ) -> None:
-        if skill_path is not None:
-            actual = _read_skill_version(skill_path)
+        # Resolve skill_path policy:
+        #   - default sentinel  → canonical project SKILL.md (version-check ON)
+        #   - SKIP_SKILL_CHECK  → caller explicitly opts out (e.g., test harness)
+        #   - any Path          → caller supplies a specific file
+        # Forces the version check to be the default; callers must opt
+        # out via SKIP_SKILL_CHECK rather than by silently omitting it.
+        resolved: Path | None
+        if skill_path is _DEFAULT_PATH_SENTINEL:
+            resolved = _DEFAULT_SKILL_PATH if _DEFAULT_SKILL_PATH.exists() else None
+        elif isinstance(skill_path, _SkipSkillCheck):
+            resolved = None
+        else:
+            resolved = skill_path  # type: ignore[assignment]
+
+        if resolved is not None:
+            actual = read_skill_version(resolved)
             if actual != EXPECTED_SKILL_VERSION:
                 raise SkillVersionError(
                     f"diagnose-ralph SKILL.md version {actual} does not "
                     f"match supervisor expected version "
-                    f"{EXPECTED_SKILL_VERSION} ({skill_path})"
+                    f"{EXPECTED_SKILL_VERSION} ({resolved})"
                 )
         self._provider = provider
         self._event_log = event_log
@@ -177,6 +212,11 @@ class DiagnosticRouter:
             return None
         try:
             body = json.loads(match.group(1))
+            # Guard against arrays / non-object bodies before indexing —
+            # body["scope"] on a list raises TypeError, on a string raises
+            # TypeError, neither of which json.loads catches.
+            if not isinstance(body, dict):
+                return None
             return Decision(
                 scope=body["scope"],
                 fix_type=body.get("fix_type"),
@@ -185,7 +225,7 @@ class DiagnosticRouter:
                 summary=body["summary"],
                 evidence=body.get("evidence", {}),
             )
-        except (json.JSONDecodeError, KeyError):
+        except (json.JSONDecodeError, KeyError, TypeError):
             return None
 
     def _build_corrective_prompt(self, original: str, bad_output: str) -> str:

--- a/src/smart_ralph/router.py
+++ b/src/smart_ralph/router.py
@@ -45,7 +45,7 @@ _DIAGNOSIS_BLOCK = re.compile(r"<diagnosis>(.*?)</diagnosis>", re.DOTALL)
 # Allowed tools the supervisor exposes to the diagnose-ralph skill. Mirrors
 # the SKILL.md frontmatter; defined here as the source of truth for the
 # headless provider invocation.
-_ALLOWED_TOOLS = [
+ALLOWED_TOOLS = [
     "Read", "Grep", "Glob",
     "Bash(jq:*)", "Bash(git log:*)", "Bash(git status:*)",
     "Bash(git diff:*)", "Bash(cat .ralph/*)",
@@ -66,12 +66,18 @@ _DEFAULT_SKILL_PATH = (
 )
 
 
-# Sentinel for "skip the skill version check entirely" — distinct from
-# default (canonical SKILL.md) and from a user-supplied custom path.
+# Sentinels for skill_path policy. Distinct typed classes (rather than
+# bare object() instances) keep the constructor's type hint exhaustive
+# under strict type checkers.
+class _UseDefault:
+    """Sentinel: use the canonical project SKILL.md."""
+
+
 class _SkipSkillCheck:
-    pass
+    """Sentinel: skip the version check entirely (test harnesses)."""
 
 
+_USE_DEFAULT_SKILL_PATH = _UseDefault()
 SKIP_SKILL_CHECK = _SkipSkillCheck()
 
 
@@ -111,30 +117,27 @@ def read_skill_version(skill_path: Path) -> int:
     )
 
 
-_DEFAULT_PATH_SENTINEL = object()
-
-
 class DiagnosticRouter:
     def __init__(
         self,
         provider: Provider,
         *,
         event_log: EventLog | None = None,
-        skill_path: "Path | _SkipSkillCheck | object" = _DEFAULT_PATH_SENTINEL,
+        skill_path: Path | _UseDefault | _SkipSkillCheck = _USE_DEFAULT_SKILL_PATH,
     ) -> None:
         # Resolve skill_path policy:
-        #   - default sentinel  → canonical project SKILL.md (version-check ON)
-        #   - SKIP_SKILL_CHECK  → caller explicitly opts out (e.g., test harness)
-        #   - any Path          → caller supplies a specific file
+        #   _UseDefault       → canonical project SKILL.md (version-check ON)
+        #   _SkipSkillCheck   → caller explicitly opts out (test harness)
+        #   Path              → caller supplies a specific file
         # Forces the version check to be the default; callers must opt
         # out via SKIP_SKILL_CHECK rather than by silently omitting it.
         resolved: Path | None
-        if skill_path is _DEFAULT_PATH_SENTINEL:
+        if isinstance(skill_path, _UseDefault):
             resolved = _DEFAULT_SKILL_PATH if _DEFAULT_SKILL_PATH.exists() else None
         elif isinstance(skill_path, _SkipSkillCheck):
             resolved = None
         else:
-            resolved = skill_path  # type: ignore[assignment]
+            resolved = skill_path
 
         if resolved is not None:
             actual = read_skill_version(resolved)
@@ -150,13 +153,13 @@ class DiagnosticRouter:
     def route(self, anomaly: Anomaly, *, context: dict[str, Any]) -> Decision:
         self._emit("diagnosis_started", anomaly.issue, {"rule": anomaly.rule})
         prompt = self._build_prompt(anomaly, context)
-        output = self._provider.run_headless(prompt, allowed_tools=list(_ALLOWED_TOOLS))
+        output = self._provider.run_headless(prompt, allowed_tools=list(ALLOWED_TOOLS))
 
         decision = self._try_parse(output)
         if decision is None:
             corrective = self._build_corrective_prompt(prompt, output)
             output = self._provider.run_headless(
-                corrective, allowed_tools=list(_ALLOWED_TOOLS),
+                corrective, allowed_tools=list(ALLOWED_TOOLS),
             )
             decision = self._try_parse(output)
         if decision is None:

--- a/src/smart_ralph/supervisor.py
+++ b/src/smart_ralph/supervisor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import traceback
 import uuid
 from collections.abc import Callable
 from pathlib import Path
@@ -123,11 +124,18 @@ class Supervisor:
                     try:
                         router.route(a, context={"issue": a.issue})
                     except Exception as e:
+                        # Include the full traceback so operators can
+                        # locate the failure without re-running with a
+                        # debugger. EventLog auto-offloads >4KB to a
+                        # blob, so even a long traceback is safe.
                         log.append(
                             event_type="diagnosis_failed", source="supervisor",
                             issue=a.issue,
-                            payload={"reason": "router_exception",
-                                     "error": f"{type(e).__name__}: {e}"},
+                            payload={
+                                "reason": "router_exception",
+                                "error": f"{type(e).__name__}: {e}",
+                                "traceback": traceback.format_exc(),
+                            },
                             sync=True,
                         )
 

--- a/src/smart_ralph/supervisor.py
+++ b/src/smart_ralph/supervisor.py
@@ -116,7 +116,20 @@ class Supervisor:
                     # router builds its prompt from anomaly + context. Richer
                     # state-snapshot context lands when state.json reading
                     # is wired (issue #9 territory).
-                    router.route(a, context={"issue": a.issue})
+                    #
+                    # A routing failure (provider timeout, network, parser
+                    # crash, etc.) must never take the whole supervised run
+                    # down. We log it as diagnosis_failed and continue.
+                    try:
+                        router.route(a, context={"issue": a.issue})
+                    except Exception as e:
+                        log.append(
+                            event_type="diagnosis_failed", source="supervisor",
+                            issue=a.issue,
+                            payload={"reason": "router_exception",
+                                     "error": f"{type(e).__name__}: {e}"},
+                            sync=True,
+                        )
 
         try:
             log.append(

--- a/src/smart_ralph/supervisor.py
+++ b/src/smart_ralph/supervisor.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from smart_ralph.anomaly import Anomaly, AnomalyDetector
 from smart_ralph.eventlog import EventLog
 from smart_ralph.ralph_client import RalphClient
+from smart_ralph.router import DiagnosticRouter
 
 
 class ConcurrentRunError(RuntimeError):
@@ -46,6 +47,7 @@ class Supervisor:
         retention_runs: int = 50,
         *,
         detector_factory: Callable[[], AnomalyDetector] = _default_detector_factory,
+        router_factory: Callable[[EventLog], DiagnosticRouter] | None = None,
     ) -> None:
         self._ralph_path = Path(ralph_path)
         self._cwd = Path(cwd)
@@ -58,6 +60,11 @@ class Supervisor:
         # can pass a factory that returns the same instance, but they opt
         # in explicitly.
         self._detector_factory = detector_factory
+        # Optional: when wired, every Anomaly the detector returns is
+        # routed through DiagnosticRouter. Default None → graceful
+        # degradation; the supervisor still records anomaly_detected
+        # events but skips routing entirely.
+        self._router_factory = router_factory
 
     def run(self, issue: int) -> tuple[int, list[dict]]:
         if not isinstance(issue, int) or issue <= 0:
@@ -91,6 +98,7 @@ class Supervisor:
         log = EventLog(meta_dir / "events.jsonl", run_id=run_id)
         log.prune_runs(keep=self._retention_runs)
         detector = self._detector_factory()
+        router = self._router_factory(log) if self._router_factory is not None else None
         process = None
         exit_code = 1
         events: list[dict] = []
@@ -103,6 +111,12 @@ class Supervisor:
                     payload={"rule": a.rule, "evidence": a.evidence},
                     sync=True,
                 )
+                if router is not None:
+                    # Context is intentionally minimal in this slice — the
+                    # router builds its prompt from anomaly + context. Richer
+                    # state-snapshot context lands when state.json reading
+                    # is wired (issue #9 territory).
+                    router.route(a, context={"issue": a.issue})
 
         try:
             log.append(

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,0 +1,74 @@
+"""Tests for ClaudeProvider (issue #8) — the v1 Provider Protocol impl
+that spawns `claude -p --permission-mode dontAsk` headlessly."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from smart_ralph.provider import ClaudeProvider
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _write_claude_shim(tmp_path: Path, body: str) -> Path:
+    shim = tmp_path / "claude"
+    shim.write_text(f"#!/usr/bin/env bash\n{body}\n")
+    shim.chmod(0o755)
+    return shim
+
+
+# ── Slice 6: ClaudeProvider spawns claude -p with dontAsk ──
+
+def test_run_headless_invokes_claude_p_with_dontask(tmp_path):
+    """The provider must invoke `claude -p` with `--permission-mode dontAsk`,
+    pass the prompt, and return stdout. We inject a stub `claude` via the
+    SMART_RALPH_CLAUDE_PATH env override so we don't depend on the real CLI."""
+    shim = _write_claude_shim(
+        tmp_path,
+        # echoes argv so we can assert flag presence; final line returns the
+        # canned diagnosis stdout the router would receive.
+        'echo "ARGS:$@" >&2\n'
+        'echo "<diagnosis>{}</diagnosis>"\n',
+    )
+
+    provider = ClaudeProvider(claude_path=shim)
+    out = provider.run_headless(
+        "do the diagnosis", allowed_tools=["Read", "Grep"],
+    )
+
+    assert "<diagnosis>" in out
+
+
+def test_run_headless_passes_prompt_to_claude(tmp_path):
+    """The prompt the router builds must reach the claude binary."""
+    out_path = tmp_path / "captured-prompt.txt"
+    shim = _write_claude_shim(
+        tmp_path,
+        # the prompt is the LAST positional arg per `claude -p <prompt>`
+        f'echo "$@" > {out_path}\n'
+        'echo "<diagnosis>{}</diagnosis>"\n',
+    )
+
+    provider = ClaudeProvider(claude_path=shim)
+    provider.run_headless("PROMPT_MARKER_xyz", allowed_tools=[])
+
+    captured = out_path.read_text()
+    assert "PROMPT_MARKER_xyz" in captured
+    assert "-p" in captured.split()
+    assert "--permission-mode" in captured
+    assert "dontAsk" in captured
+
+
+def test_provider_uses_env_override_for_claude_path(tmp_path, monkeypatch):
+    """Default constructor honours SMART_RALPH_CLAUDE_PATH so callers can
+    pin a specific binary without threading it through every config layer."""
+    shim = _write_claude_shim(
+        tmp_path,
+        'echo "<diagnosis>{}</diagnosis>"\n',
+    )
+    monkeypatch.setenv("SMART_RALPH_CLAUDE_PATH", str(shim))
+
+    provider = ClaudeProvider()  # no claude_path arg — picks up the env
+    out = provider.run_headless("x", allowed_tools=[])
+
+    assert "<diagnosis>" in out

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -72,3 +72,45 @@ def test_provider_uses_env_override_for_claude_path(tmp_path, monkeypatch):
     out = provider.run_headless("x", allowed_tools=[])
 
     assert "<diagnosis>" in out
+
+
+def test_run_headless_returns_empty_string_on_timeout(tmp_path):
+    """A hung claude must not propagate TimeoutExpired up to the supervisor.
+    The provider returns "" so the router treats the response as malformed
+    and runs its retry/escalation path instead of crashing the run."""
+    # Shim sleeps longer than the provider timeout.
+    shim = _write_claude_shim(tmp_path, 'sleep 5\n')
+    provider = ClaudeProvider(claude_path=shim, timeout_seconds=1)
+
+    out = provider.run_headless("x", allowed_tools=[])
+    assert out == ""
+
+
+def test_run_headless_returns_empty_string_when_binary_missing(tmp_path):
+    """If the claude binary disappears between health-check and invocation
+    (or the shim was never executable), the provider absorbs the FileNotFoundError
+    rather than crashing the supervisor."""
+    missing = tmp_path / "does-not-exist"
+    provider = ClaudeProvider(claude_path=missing, timeout_seconds=1)
+
+    out = provider.run_headless("x", allowed_tools=[])
+    assert out == ""
+
+
+def test_run_headless_runs_in_supplied_cwd(tmp_path):
+    """The provider must run claude in a specific cwd so the on-disk
+    .claude/skills/ tree can be discovered. Otherwise SKILL.md resolution
+    depends on whatever directory the supervisor was launched from."""
+    workdir = tmp_path / "workspace"
+    workdir.mkdir()
+    shim = _write_claude_shim(
+        tmp_path,
+        f'pwd > {tmp_path / "captured-cwd.txt"}\n'
+        f'echo "<diagnosis>{{}}</diagnosis>"\n',
+    )
+
+    provider = ClaudeProvider(claude_path=shim, cwd=workdir)
+    provider.run_headless("x", allowed_tools=[])
+
+    captured = (tmp_path / "captured-cwd.txt").read_text().strip()
+    assert Path(captured).resolve() == workdir.resolve()

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -211,6 +211,21 @@ def test_router_accepts_matching_skill_version(tmp_path):
     )  # constructs without raising
 
 
+def test_router_default_skill_path_runs_version_check_against_canonical(monkeypatch):
+    """Constructing the router without skill_path must not silently skip
+    the check. It loads the canonical project SKILL.md and validates
+    against EXPECTED_SKILL_VERSION."""
+    monkeypatch.setattr("smart_ralph.router.EXPECTED_SKILL_VERSION", 999)
+
+    with pytest.raises(SkillVersionError) as exc:
+        DiagnosticRouter(provider=FakeProvider([]))
+
+    msg = str(exc.value)
+    assert "999" in msg  # the bumped expected version
+    assert "diagnose-ralph" in msg
+    assert "SKILL.md" in msg
+
+
 # ── Parser robustness: arrays and multi-block ──────────────
 
 def test_parser_returns_needs_human_when_diagnosis_body_is_json_array():

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1,0 +1,210 @@
+"""Tests for DiagnosticRouter (issue #8).
+
+The router takes an Anomaly + supervisor context, invokes a Provider
+headlessly, parses the <diagnosis>{...}</diagnosis> XML block, and
+returns a Decision. This slice is observe-only — no fix application.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from smart_ralph.anomaly import Anomaly
+from smart_ralph.eventlog import EventLog
+from smart_ralph.router import DiagnosticRouter
+
+
+class FakeProvider:
+    """In-memory provider stub. Records every prompt it receives and
+    replays canned stdout strings in order. Tests use it to drive the
+    router without touching the real `claude` CLI."""
+
+    def __init__(self, responses: list[str]) -> None:
+        self._responses = list(responses)
+        self.prompts: list[str] = []
+
+    def run_headless(self, prompt: str, *, allowed_tools: list[str]) -> str:
+        self.prompts.append(prompt)
+        if not self._responses:
+            raise AssertionError("FakeProvider exhausted responses")
+        return self._responses.pop(0)
+
+
+_VALID_DIAGNOSIS = (
+    '<diagnosis>'
+    '{"scope":"orchestrator",'
+    '"fix_type":"state_patch",'
+    '"action":{"path":".ralph/state.json","key":"foo","value":"bar"},'
+    '"confidence":"high",'
+    '"summary":"stale state on issue 7",'
+    '"evidence":{"exit_code":1}}'
+    '</diagnosis>'
+)
+
+
+def _ctx() -> dict[str, Any]:
+    return {
+        "issue": 7,
+        "state_snapshot": {},
+        "log_tail": [],
+        "iterations": 0,
+    }
+
+
+def _anomaly() -> Anomaly:
+    return Anomaly(
+        rule="ralph_nonzero_exit",
+        issue=7,
+        evidence={"exit_code": 1, "log_tail": ["err"]},
+    )
+
+
+# ── Slice 1: tracer ────────────────────────────────────────
+
+def test_router_returns_parsed_decision_from_canned_diagnosis():
+    provider = FakeProvider(responses=[_VALID_DIAGNOSIS])
+    router = DiagnosticRouter(provider=provider)
+
+    decision = router.route(_anomaly(), context=_ctx())
+
+    assert decision.scope == "orchestrator"
+    assert decision.fix_type == "state_patch"
+    assert decision.action == {
+        "path": ".ralph/state.json", "key": "foo", "value": "bar",
+    }
+    assert decision.confidence == "high"
+    assert decision.summary == "stale state on issue 7"
+    assert decision.evidence == {"exit_code": 1}
+    assert decision.needs_human is False
+    # Provider was called exactly once with a prompt that referenced the rule.
+    assert len(provider.prompts) == 1
+    assert "ralph_nonzero_exit" in provider.prompts[0]
+
+
+# ── Slice 2: lifecycle event emission ──────────────────────
+
+def _read_jsonl(path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines()]
+
+
+def test_router_logs_diagnosis_started_and_completed(tmp_path):
+    provider = FakeProvider(responses=[_VALID_DIAGNOSIS])
+    log = EventLog(tmp_path / "events.jsonl", run_id="run-r1")
+    router = DiagnosticRouter(provider=provider, event_log=log)
+
+    router.route(_anomaly(), context=_ctx())
+
+    entries = _read_jsonl(tmp_path / "events.jsonl")
+    types = [e["type"] for e in entries]
+    assert types == ["diagnosis_started", "diagnosis_completed"]
+
+    started = entries[0]
+    assert started["source"] == "skill:diagnose-ralph"
+    assert started["issue"] == 7
+    assert started["payload"]["rule"] == "ralph_nonzero_exit"
+
+    completed = entries[1]
+    assert completed["source"] == "skill:diagnose-ralph"
+    assert completed["issue"] == 7
+    assert completed["payload"]["scope"] == "orchestrator"
+    assert completed["payload"]["fix_type"] == "state_patch"
+    assert completed["payload"]["confidence"] == "high"
+
+
+# ── Slice 3: corrective retry on malformed output ──────────
+
+def test_malformed_first_response_triggers_one_corrective_retry(tmp_path):
+    provider = FakeProvider(responses=["nope, no diagnosis here", _VALID_DIAGNOSIS])
+    log = EventLog(tmp_path / "events.jsonl", run_id="run-retry")
+    router = DiagnosticRouter(provider=provider, event_log=log)
+
+    decision = router.route(_anomaly(), context=_ctx())
+
+    # The router called the provider twice — once with the original prompt,
+    # once with a corrective prompt that referenced the first malformed
+    # output and asked for a valid <diagnosis> block.
+    assert len(provider.prompts) == 2
+    retry_prompt = provider.prompts[1]
+    assert "<diagnosis>" in retry_prompt
+    assert "nope, no diagnosis here" in retry_prompt or "previous" in retry_prompt.lower()
+
+    # The successful retry produces a normal decision, not needs_human.
+    assert decision.scope == "orchestrator"
+    assert decision.needs_human is False
+
+    # diagnosis_started fires once; diagnosis_completed fires once.
+    types = [e["type"] for e in _read_jsonl(tmp_path / "events.jsonl")]
+    assert types.count("diagnosis_started") == 1
+    assert types.count("diagnosis_completed") == 1
+
+
+# ── Slice 4: two malformed → needs_human + diagnosis_failed ──
+
+def test_two_malformed_responses_escalate_to_needs_human(tmp_path):
+    """If both the original call and its corrective retry return malformed
+    output, the router emits diagnosis_failed and returns a Decision with
+    needs_human=True. No third provider call is ever made."""
+    provider = FakeProvider(responses=["junk one", "still junk"])
+    log = EventLog(tmp_path / "events.jsonl", run_id="run-bad")
+    router = DiagnosticRouter(provider=provider, event_log=log)
+
+    decision = router.route(_anomaly(), context=_ctx())
+
+    assert decision.needs_human is True
+    assert decision.scope == "unknown"
+    # Provider called exactly twice — never a third time.
+    assert len(provider.prompts) == 2
+
+    types = [e["type"] for e in _read_jsonl(tmp_path / "events.jsonl")]
+    assert "diagnosis_started" in types
+    assert "diagnosis_failed" in types
+    # diagnosis_completed must NOT fire when escalating.
+    assert "diagnosis_completed" not in types
+
+    failed = next(
+        e for e in _read_jsonl(tmp_path / "events.jsonl")
+        if e["type"] == "diagnosis_failed"
+    )
+    assert failed["payload"]["reason"] == "malformed_output"
+    assert failed["payload"]["attempts"] == 2
+
+
+# ── Slice 5: skill version mismatch refuses to run ─────────
+
+import pytest
+
+from smart_ralph.router import SkillVersionError
+
+
+def _write_skill(path, *, version: int) -> None:
+    path.write_text(
+        f"---\n"
+        f"version: {version}\n"
+        f"description: programmatic-use only\n"
+        f"---\n"
+        f"# diagnose-ralph body\n"
+    )
+
+
+def test_router_refuses_to_run_on_skill_version_mismatch(tmp_path):
+    skill_md = tmp_path / "SKILL.md"
+    _write_skill(skill_md, version=99)  # supervisor expects v1
+
+    with pytest.raises(SkillVersionError) as exc:
+        DiagnosticRouter(
+            provider=FakeProvider([]),
+            skill_path=skill_md,
+        )
+    msg = str(exc.value).lower()
+    assert "version" in msg
+    assert "99" in msg
+
+
+def test_router_accepts_matching_skill_version(tmp_path):
+    skill_md = tmp_path / "SKILL.md"
+    _write_skill(skill_md, version=1)
+
+    DiagnosticRouter(
+        provider=FakeProvider([_VALID_DIAGNOSIS]),
+        skill_path=skill_md,
+    )  # constructs without raising

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -226,6 +226,25 @@ def test_router_default_skill_path_runs_version_check_against_canonical(monkeypa
     assert "SKILL.md" in msg
 
 
+def test_router_default_skill_path_raises_when_canonical_missing(monkeypatch, tmp_path):
+    """The whole point of making the version check the default is that it
+    can't be silently bypassed. If the canonical SKILL.md cannot be
+    located (e.g., non-standard install layout, future shiv-bundled
+    distribution per #28), construction must raise — never fall through
+    to a no-op."""
+    monkeypatch.setattr(
+        "smart_ralph.router._DEFAULT_SKILL_PATH",
+        tmp_path / "definitely-not-here" / "SKILL.md",
+    )
+
+    with pytest.raises(SkillVersionError) as exc:
+        DiagnosticRouter(provider=FakeProvider([]))
+
+    msg = str(exc.value).lower()
+    assert "skill.md" in msg
+    assert "skip_skill_check" in msg or "not found" in msg or "missing" in msg
+
+
 # ── Parser robustness: arrays and multi-block ──────────────
 
 def test_parser_returns_needs_human_when_diagnosis_body_is_json_array():

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -9,9 +9,15 @@ from __future__ import annotations
 import json
 from typing import Any
 
+import pytest
+
 from smart_ralph.anomaly import Anomaly
 from smart_ralph.eventlog import EventLog
-from smart_ralph.router import DiagnosticRouter
+from smart_ralph.router import (
+    SKIP_SKILL_CHECK,
+    DiagnosticRouter,
+    SkillVersionError,
+)
 
 
 class FakeProvider:
@@ -171,11 +177,6 @@ def test_two_malformed_responses_escalate_to_needs_human(tmp_path):
 
 # ── Slice 5: skill version mismatch refuses to run ─────────
 
-import pytest
-
-from smart_ralph.router import SkillVersionError
-
-
 def _write_skill(path, *, version: int) -> None:
     path.write_text(
         f"---\n"
@@ -208,3 +209,39 @@ def test_router_accepts_matching_skill_version(tmp_path):
         provider=FakeProvider([_VALID_DIAGNOSIS]),
         skill_path=skill_md,
     )  # constructs without raising
+
+
+# ── Parser robustness: arrays and multi-block ──────────────
+
+def test_parser_returns_needs_human_when_diagnosis_body_is_json_array():
+    """If the model emits a JSON array (or any non-object), the parser
+    must not crash. Two malformed responses → needs_human."""
+    arr = '<diagnosis>[1,2,3]</diagnosis>'
+    provider = FakeProvider(responses=[arr, arr])
+    router = DiagnosticRouter(provider=provider, skill_path=SKIP_SKILL_CHECK)
+
+    decision = router.route(_anomaly(), context=_ctx())
+
+    assert decision.needs_human is True
+    assert decision.scope == "unknown"
+
+
+def test_parser_picks_first_when_multiple_diagnosis_blocks_present():
+    """The SKILL.md hard-rule says exactly one block; if the model emits
+    more than one, the non-greedy regex picks the first. Pin that
+    tie-break so future parser changes can't silently shift behaviour."""
+    two_blocks = (
+        '<diagnosis>{"scope":"orchestrator","fix_type":"restart",'
+        '"action":{},"confidence":"high","summary":"first","evidence":{}}'
+        '</diagnosis>\n'
+        '<diagnosis>{"scope":"product","fix_type":null,'
+        '"action":null,"confidence":"low","summary":"second","evidence":{}}'
+        '</diagnosis>'
+    )
+    provider = FakeProvider(responses=[two_blocks])
+    router = DiagnosticRouter(provider=provider, skill_path=SKIP_SKILL_CHECK)
+
+    decision = router.route(_anomaly(), context=_ctx())
+
+    assert decision.summary == "first"
+    assert decision.scope == "orchestrator"

--- a/tests/test_skill_diagnose_ralph.py
+++ b/tests/test_skill_diagnose_ralph.py
@@ -12,7 +12,7 @@ from smart_ralph.router import (
     EXPECTED_SKILL_VERSION,
     DiagnosticRouter,
     SkillVersionError,
-    _ALLOWED_TOOLS,
+    ALLOWED_TOOLS,
     read_skill_version,
 )
 
@@ -72,7 +72,7 @@ def test_router_accepts_the_real_skill_file():
 
 
 def test_skill_allowed_tools_match_router_allowlist():
-    """The skill's frontmatter `allowed-tools:` list and router._ALLOWED_TOOLS
+    """The skill's frontmatter `allowed-tools:` list and router.ALLOWED_TOOLS
     are two sources of truth — drift means the supervisor's --allowed-tools
     invocation diverges from what the on-disk skill advertises. Parse the
     YAML list and assert exact set equality so a missing entry on either
@@ -102,8 +102,8 @@ def test_skill_allowed_tools_match_router_allowlist():
                 # next top-level key
                 break
 
-    assert set(skill_tools) == set(_ALLOWED_TOOLS), (
-        f"SKILL.md allowed-tools and router._ALLOWED_TOOLS have drifted.\n"
-        f"  in SKILL only: {set(skill_tools) - set(_ALLOWED_TOOLS)}\n"
-        f"  in router only: {set(_ALLOWED_TOOLS) - set(skill_tools)}"
+    assert set(skill_tools) == set(ALLOWED_TOOLS), (
+        f"SKILL.md allowed-tools and router.ALLOWED_TOOLS have drifted.\n"
+        f"  in SKILL only: {set(skill_tools) - set(ALLOWED_TOOLS)}\n"
+        f"  in router only: {set(ALLOWED_TOOLS) - set(skill_tools)}"
     )

--- a/tests/test_skill_diagnose_ralph.py
+++ b/tests/test_skill_diagnose_ralph.py
@@ -1,0 +1,70 @@
+"""Tests for the diagnose-ralph SKILL.md contract.
+
+The skill is invoked headlessly via Claude. Its frontmatter (version,
+allowed-tools, programmatic-use marker) and body (input/output contract)
+are what the supervisor and Claude agree on, so they get pinned by tests.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from smart_ralph.router import (
+    EXPECTED_SKILL_VERSION,
+    DiagnosticRouter,
+    SkillVersionError,
+    _read_skill_version,
+)
+
+SKILL = Path(__file__).parent.parent / ".claude" / "skills" / "diagnose-ralph" / "SKILL.md"
+
+
+def test_skill_file_exists():
+    assert SKILL.is_file(), f"missing skill file: {SKILL}"
+
+
+def test_skill_frontmatter_version_matches_supervisor_expectation():
+    """Reading the version through the same parser the router uses keeps
+    the on-disk skill and the in-code expected_version in lockstep."""
+    actual = _read_skill_version(SKILL)
+    assert actual == EXPECTED_SKILL_VERSION
+
+
+def test_skill_frontmatter_marks_programmatic_use_only():
+    """The skill is invoked by the supervisor headlessly, never from the
+    interactive Skill picker. The frontmatter description must say so so
+    a human running /skill won't accidentally trigger it."""
+    text = SKILL.read_text()
+    assert "programmatic" in text.lower()
+
+
+def test_skill_frontmatter_lists_allowed_tools():
+    """The supervisor invokes Claude with --allowed-tools matching the
+    skill's frontmatter. The list must include Read/Grep/Glob plus the
+    Edit-scoped-to-state.json + targeted Bash entries the router code
+    sends along."""
+    text = SKILL.read_text()
+    # Cheap text checks — the YAML parser is intentionally tiny in
+    # router.py so we just verify each tool name appears in the file.
+    for tool in ["Read", "Grep", "Glob", "Edit", "Bash", "state.json"]:
+        assert tool in text, f"allowed-tools missing entry referencing {tool!r}"
+
+
+def test_skill_body_documents_diagnosis_xml_output_contract():
+    """The body must tell Claude how to format its response so the
+    router's regex-based parser can pick it up."""
+    text = SKILL.read_text()
+    assert "<diagnosis>" in text
+    assert "</diagnosis>" in text
+    for required_field in ["scope", "fix_type", "action", "confidence", "summary"]:
+        assert required_field in text, f"output contract missing field {required_field!r}"
+
+
+def test_router_accepts_the_real_skill_file():
+    """End-to-end: the router's version check passes against the real
+    on-disk SKILL.md."""
+
+    class _NullProvider:
+        def run_headless(self, prompt, *, allowed_tools):
+            raise AssertionError("provider should not be called during construction")
+
+    DiagnosticRouter(provider=_NullProvider(), skill_path=SKILL)

--- a/tests/test_skill_diagnose_ralph.py
+++ b/tests/test_skill_diagnose_ralph.py
@@ -12,7 +12,8 @@ from smart_ralph.router import (
     EXPECTED_SKILL_VERSION,
     DiagnosticRouter,
     SkillVersionError,
-    _read_skill_version,
+    _ALLOWED_TOOLS,
+    read_skill_version,
 )
 
 SKILL = Path(__file__).parent.parent / ".claude" / "skills" / "diagnose-ralph" / "SKILL.md"
@@ -25,7 +26,7 @@ def test_skill_file_exists():
 def test_skill_frontmatter_version_matches_supervisor_expectation():
     """Reading the version through the same parser the router uses keeps
     the on-disk skill and the in-code expected_version in lockstep."""
-    actual = _read_skill_version(SKILL)
+    actual = read_skill_version(SKILL)
     assert actual == EXPECTED_SKILL_VERSION
 
 
@@ -68,3 +69,41 @@ def test_router_accepts_the_real_skill_file():
             raise AssertionError("provider should not be called during construction")
 
     DiagnosticRouter(provider=_NullProvider(), skill_path=SKILL)
+
+
+def test_skill_allowed_tools_match_router_allowlist():
+    """The skill's frontmatter `allowed-tools:` list and router._ALLOWED_TOOLS
+    are two sources of truth — drift means the supervisor's --allowed-tools
+    invocation diverges from what the on-disk skill advertises. Parse the
+    YAML list and assert exact set equality so a missing entry on either
+    side fails fast."""
+    text = SKILL.read_text()
+
+    # Slice the frontmatter (between the first pair of "---" markers).
+    parts = text.split("---", 2)
+    assert len(parts) >= 3, "SKILL.md is missing a YAML frontmatter block"
+    frontmatter = parts[1]
+
+    # Pull the `allowed-tools:` block. It's a YAML list of "  - <entry>"
+    # lines that ends at the next top-level key (no leading whitespace).
+    in_block = False
+    skill_tools: list[str] = []
+    for line in frontmatter.splitlines():
+        stripped = line.strip()
+        if stripped == "allowed-tools:":
+            in_block = True
+            continue
+        if in_block:
+            if line.startswith("  - "):
+                skill_tools.append(line[4:].strip())
+            elif stripped == "" or line.startswith("  "):
+                continue
+            else:
+                # next top-level key
+                break
+
+    assert set(skill_tools) == set(_ALLOWED_TOOLS), (
+        f"SKILL.md allowed-tools and router._ALLOWED_TOOLS have drifted.\n"
+        f"  in SKILL only: {set(skill_tools) - set(_ALLOWED_TOOLS)}\n"
+        f"  in router only: {set(_ALLOWED_TOOLS) - set(skill_tools)}"
+    )

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import pytest
 
 from smart_ralph.anomaly import Anomaly, AnomalyDetector
+from smart_ralph.eventlog import EventLog
+from smart_ralph.router import DiagnosticRouter
 from smart_ralph.supervisor import ConcurrentRunError, HealthCheckError, Supervisor
 
 FIXTURES = Path(__file__).parent / "fixtures" / "fake_ralph"
@@ -420,6 +422,77 @@ def test_default_detector_factory_isolates_log_tail_across_runs(tmp_path):
             f"run {run_id} log_tail has {len(log_tail)} lines — state leaked"
             f" from a prior run (fixture prints only 3 per invocation)"
         )
+
+
+def test_supervisor_routes_anomalies_to_diagnostic_router(tmp_path):
+    """When a router_factory is injected, every anomaly the detector
+    returns is fed to DiagnosticRouter.route(). The full chain
+    anomaly_detected → diagnosis_started → diagnosis_completed must
+    appear in events.jsonl in that order."""
+    canned = (
+        '<diagnosis>'
+        '{"scope":"orchestrator",'
+        '"fix_type":"state_patch",'
+        '"action":{},'
+        '"confidence":"high",'
+        '"summary":"x",'
+        '"evidence":{}}'
+        '</diagnosis>'
+    )
+
+    class _CannedProvider:
+        def run_headless(self, prompt, *, allowed_tools):
+            return canned
+
+    def router_factory(log: EventLog) -> DiagnosticRouter:
+        return DiagnosticRouter(provider=_CannedProvider(), event_log=log)
+
+    _init_repo(tmp_path)
+    supervisor = Supervisor(
+        ralph_path=FIXTURES / "exits_nonzero.sh",
+        cwd=tmp_path,
+        required_tools=_all_tools_present(),
+        router_factory=router_factory,
+    )
+    supervisor.run(issue=42)
+
+    events_path = tmp_path / ".smart-ralph" / "events.jsonl"
+    types = [
+        json.loads(line)["type"]
+        for line in events_path.read_text().splitlines()
+    ]
+
+    assert "anomaly_detected" in types
+    assert "diagnosis_started" in types
+    assert "diagnosis_completed" in types
+
+    # Diagnostic events must come AFTER the anomaly that triggered them.
+    anomaly_idx = types.index("anomaly_detected")
+    started_idx = types.index("diagnosis_started")
+    completed_idx = types.index("diagnosis_completed")
+    assert anomaly_idx < started_idx < completed_idx
+
+
+def test_supervisor_without_router_factory_logs_anomaly_only(tmp_path):
+    """Default behaviour with no router_factory: anomaly_detected lands
+    but no diagnostic events fire (graceful degradation when the diagnose
+    pathway isn't configured)."""
+    _init_repo(tmp_path)
+    supervisor = Supervisor(
+        ralph_path=FIXTURES / "exits_nonzero.sh",
+        cwd=tmp_path,
+        required_tools=_all_tools_present(),
+    )
+    supervisor.run(issue=43)
+
+    events_path = tmp_path / ".smart-ralph" / "events.jsonl"
+    types = [
+        json.loads(line)["type"]
+        for line in events_path.read_text().splitlines()
+    ]
+    assert "anomaly_detected" in types
+    assert "diagnosis_started" not in types
+    assert "diagnosis_completed" not in types
 
 
 def test_zero_exit_does_not_write_anomaly_detected(tmp_path):

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -7,7 +7,7 @@ import pytest
 
 from smart_ralph.anomaly import Anomaly, AnomalyDetector
 from smart_ralph.eventlog import EventLog
-from smart_ralph.router import DiagnosticRouter
+from smart_ralph.router import SKIP_SKILL_CHECK, DiagnosticRouter
 from smart_ralph.supervisor import ConcurrentRunError, HealthCheckError, Supervisor
 
 FIXTURES = Path(__file__).parent / "fixtures" / "fake_ralph"
@@ -471,6 +471,44 @@ def test_supervisor_routes_anomalies_to_diagnostic_router(tmp_path):
     started_idx = types.index("diagnosis_started")
     completed_idx = types.index("diagnosis_completed")
     assert anomaly_idx < started_idx < completed_idx
+
+
+def test_router_exception_does_not_kill_supervisor_run(tmp_path):
+    """A misbehaving router (provider crash, network, anything) must not
+    take the whole orchestration down. Failure is logged as
+    diagnosis_failed and the supervisor continues normally."""
+
+    class _ExplodingProvider:
+        def run_headless(self, prompt, *, allowed_tools):
+            raise RuntimeError("simulated provider explosion")
+
+    def router_factory(log: EventLog) -> DiagnosticRouter:
+        return DiagnosticRouter(
+            provider=_ExplodingProvider(),
+            event_log=log,
+            skill_path=SKIP_SKILL_CHECK,
+        )
+
+    _init_repo(tmp_path)
+    supervisor = Supervisor(
+        ralph_path=FIXTURES / "exits_nonzero.sh",
+        cwd=tmp_path,
+        required_tools=_all_tools_present(),
+        router_factory=router_factory,
+    )
+    exit_code, _ = supervisor.run(issue=77)
+    # Run completes; ralph's exit code is what surfaces.
+    assert exit_code == 1
+
+    events_path = tmp_path / ".smart-ralph" / "events.jsonl"
+    types = [
+        json.loads(line)["type"]
+        for line in events_path.read_text().splitlines()
+    ]
+    assert "anomaly_detected" in types
+    assert "diagnosis_failed" in types
+    # Supervisor's lifecycle terminates cleanly.
+    assert types[-1] == "run_ended"
 
 
 def test_supervisor_without_router_factory_logs_anomaly_only(tmp_path):


### PR DESCRIPTION
## Summary

First intelligence slice. Wires the anomaly detector (#7) into a headless Claude invocation that classifies the failure and emits a structured `<diagnosis>` block. Observe-only — the router logs the proposal but never applies a fix. Repair pathway lands in #9.

- **`src/smart_ralph/router.py`** — `DiagnosticRouter`, `Decision` dataclass, `Provider` Protocol. On each Anomaly: builds a prompt, invokes the provider, parses `<diagnosis>{...}</diagnosis>`, logs `diagnosis_started` + `diagnosis_completed`. Malformed output → exactly one corrective retry; second failure → `diagnosis_failed` + needs_human Decision. `SkillVersionError` raised at construction if the on-disk SKILL.md version drifts from the supervisor's expected version.
- **`src/smart_ralph/provider.py`** — `ClaudeProvider`, the v1 Protocol impl. Spawns `claude -p --permission-mode dontAsk` with `--allowed-tools` populated from the router's allowlist. Honors `SMART_RALPH_CLAUDE_PATH` for testability and pinning. 300s timeout per invocation.
- **`.claude/skills/diagnose-ralph/SKILL.md`** — frontmatter (`version: 1`, programmatic-use marker, allowlist with targeted Bash entries + `Edit(.ralph/state.json)`), body documents input envelope and `<diagnosis>` output contract (scope/fix_type/action/confidence/summary/evidence) with hard rules for Claude.
- **`src/smart_ralph/supervisor.py`** — new optional `router_factory` kwarg. When provided, every Anomaly is routed in addition to being recorded. Default `None` → graceful degradation; anomalies still logged but routing skipped.

Closes #8.

## Test plan

71/71 tests pass (`.venv/bin/python -m pytest`). New coverage across four test files:

- [x] **router**: tracer parses Decision from canned diagnosis; logs `diagnosis_started` + `diagnosis_completed`; corrective retry on malformed output (exactly 1 retry); two malformed → `diagnosis_failed` + needs_human Decision (no third call); skill version mismatch raises `SkillVersionError`; version match constructs cleanly
- [x] **provider**: `claude -p --permission-mode dontAsk` invoked correctly; prompt reaches the binary; `SMART_RALPH_CLAUDE_PATH` env override honored
- [x] **skill**: file exists; frontmatter version matches `EXPECTED_SKILL_VERSION`; programmatic-use marker present; allowed-tools list mentions Read/Grep/Glob/Edit/Bash/state.json; body documents `<diagnosis>` block and all six required fields; real router constructs against real on-disk skill
- [x] **supervisor integration**: anomalies route through the injected router — full chain `anomaly_detected` → `diagnosis_started` → `diagnosis_completed` lands in events.jsonl in the right order; default behaviour without `router_factory` still logs anomalies but emits no diagnostic events

## Manual verification

(Same caveat as #7: live dashboard surfacing of the new diagnostic events isn't wired through the CLI yet — that's the same gap noted in the project memory. Manual verification via tailing events.jsonl works.)

- [ ] Run `./smart-ralph <issue>` with a deliberately failing fixture; tail `.smart-ralph/events.jsonl` and confirm the chain `anomaly_detected → diagnosis_started → diagnosis_completed` appears (requires wiring `router_factory` into the CLI — currently `None` by default; can demo via a small Python harness that constructs the supervisor with a real `ClaudeProvider`-backed `DiagnosticRouter`)